### PR TITLE
v0.2.1

### DIFF
--- a/internal/modes/default.go
+++ b/internal/modes/default.go
@@ -3,34 +3,41 @@ package modes
 import (
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/padi2312/compose-check-updates/internal"
 )
 
 func Default(updateInfos []internal.UpdateInfo, ccuFlags internal.CCUFlags) {
+	var wg sync.WaitGroup
 	for _, i := range updateInfos {
-		if i.HasNewVersion(ccuFlags.Major, ccuFlags.Minor, ccuFlags.Patch) {
-			if !ccuFlags.Update && !ccuFlags.Restart {
-				// If no flags are provided, just print the new version
-				slog.Info(fmt.Sprintf("New version for %s: %s -> %s", i.ImageName, i.CurrentTag, i.LatestTag))
-			}
-
-			if ccuFlags.Update {
-				if err := i.Update(); err != nil {
-					slog.Error(fmt.Sprintf("error updating file: %v", err))
-					continue
+		wg.Add(1)
+		go func(i internal.UpdateInfo) {
+			defer wg.Done()
+			if i.HasNewVersion(ccuFlags.Major, ccuFlags.Minor, ccuFlags.Patch) {
+				if !ccuFlags.Update && !ccuFlags.Restart {
+					// If no flags are provided, just print the new version
+					slog.Info(fmt.Sprintf("New version for %s: %s -> %s", i.ImageName, i.CurrentTag, i.LatestTag))
 				}
-				slog.Info(fmt.Sprintf("File [%s] | Image %s has new version %s", i.FilePath, i.ImageName, i.LatestTag))
-			}
 
-			if ccuFlags.Restart {
-				if err := i.Restart(); err != nil {
-					slog.Error(fmt.Sprintf("error restarting service: %v", err))
-					continue
+				if ccuFlags.Update {
+					if err := i.Update(); err != nil {
+						slog.Error(fmt.Sprintf("error updating file: %v", err))
+						return
+					}
+					slog.Info(fmt.Sprintf("File [%s] | Image %s has new version %s", i.FilePath, i.ImageName, i.LatestTag))
 				}
-				slog.Info(fmt.Sprintf("Compose file [%s] restarted", i.FilePath))
+
+				if ccuFlags.Restart {
+					if err := i.Restart(); err != nil {
+						slog.Error(fmt.Sprintf("error restarting service: %v", err))
+						return
+					}
+					slog.Info(fmt.Sprintf("Compose file [%s] restarted", i.FilePath))
+				}
 			}
-		}
+		}(i)
 	}
+	wg.Wait()
 
 }

--- a/internal/update_info.go
+++ b/internal/update_info.go
@@ -85,12 +85,21 @@ func (u *UpdateInfo) Update() error {
 }
 
 func (u *UpdateInfo) Restart() error {
-	// Execute docker-compose up -d here with os
-	cmd := exec.Command("docker-compose", "-f", u.FilePath, "up", "-d")
+	dockerComposeCommand := "docker-compose"
+	_, err := exec.LookPath(dockerComposeCommand)
+	if err != nil {
+		dockerComposeCommand = "docker compose"
+		_, err = exec.LookPath(dockerComposeCommand)
+		if err != nil {
+			return err
+		}
+	}
+
+	cmd := exec.Command(dockerComposeCommand, "-f", u.FilePath, "up", "-d")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/padi2312/compose-check-updates/internal/modes"
 )
 
-var version = "0.2.0"
+var version = "0.2.1"
 
 func main() {
 	// Set colorized logger


### PR DESCRIPTION
- This pull request enhances concurrency and error handling in compose-check-updates.
- Introduces sync.WaitGroup in internal/modes/default.go for concurrent update checks and restarts.
- Adds goroutines main.go for improved performance through parallel operations.
- Upgrades error handling in internal/update_info.go to support both docker-compose and docker compose.
- Updates the version from 0.2.0 to 0.2.1 in main.go to reflect these changes.