### PR TITLE
Develop

### DIFF
--- a/internal/update_info.go
+++ b/internal/update_info.go
@@ -95,7 +95,12 @@ func (u *UpdateInfo) Restart() error {
 		}
 	}
 
-	cmd := exec.Command(dockerComposeCommand, "-f", u.FilePath, "up", "-d")
+	var cmd *exec.Cmd
+	if dockerComposeCommand == "docker-compose" {
+		cmd = exec.Command("docker-compose", "-f", u.FilePath, "up", "-d")
+	} else {
+		cmd = exec.Command("docker", "compose", "-f", u.FilePath, "up", "-d")
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/padi2312/compose-check-updates/internal/modes"
 )
 
-var version = "0.2.1"
+var version = "0.2.2"
 
 func main() {
 	// Set colorized logger


### PR DESCRIPTION
This pull request includes changes to improve the handling of Docker commands and updates the version number.

Improvements to Docker command handling:

* [`internal/update_info.go`](diffhunk://#diff-8900fb94c0deb85aa3f5e147b92e5b4659384518c5eb17f9e28c3c1175f33cc3L98-R103): Modified the `Restart` method to handle both `docker-compose` and `docker compose` commands based on the value of `dockerComposeCommand`.

Version update:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L13-R13): Updated the version variable from `0.2.1` to `0.2.2`.