### PR TITLE
feat: add update functionality with version management and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Easily update Docker Compose image tags to their latest versions.
     - [Linux](#linux)
 - [Usage](#usage)
 - [Flags](#flags)
+- [Keeping ccu up to date](#keeping-ccu-up-to-date)
 - [Interactive mode](#interactive-mode)
 - [How does it work?](#how-does-it-work)
   - [Images without semver tags](#images-without-semver-tags)
@@ -103,18 +104,46 @@ You can also control the update behavior by using the flags described below.
 > [!IMPORTANT]
 > When using `-i` for interactive mode other arguments (except `-d` for directory and `-exclude`) will be ignored. See [Interactive mode](#interactive-mode).
 
-| Flag       | Description                                                    | Default                 |
-| ---------- | -------------------------------------------------------------- | ----------------------- |
-| `-h`       | Show help message                                              | `false`                 |
-| `-u`       | Update the Docker Compose files with the new image tags        | `false`                 |
-| `-r`       | Restart the services after updating the Docker Compose files   | `false`                 |
-| `-i`       | Launch the full-screen TUI to pick which images to update      | `false`                 |
-| `-d`       | Specify the directory to scan for Docker Compose files         | `.` (current directory) |
-| `-f`       | Full update mode, checks updates to latest semver version      | `false`                 |
-| `-major`   | Only suggest major version updates                             | `false`                 |
-| `-minor`   | Only suggest minor version updates                             | `false`                 |
-| `-patch`   | Only suggest patch version updates                             | `true`                  |
-| `-exclude` | Exclude specific services from being updated (comma-separated) | `none`                  |
+| Flag            | Description                                                                | Default                 |
+| --------------- | -------------------------------------------------------------------------- | ----------------------- |
+| `-h`            | Show help message                                                          | `false`                 |
+| `-u`            | Update the Docker Compose files with the new image tags                    | `false`                 |
+| `-r`            | Restart the services after updating the Docker Compose files               | `false`                 |
+| `-i`            | Launch the full-screen TUI to pick which images to update                  | `false`                 |
+| `-d`            | Specify the directory to scan for Docker Compose files                     | `.` (current directory) |
+| `-f`            | Full update mode, checks updates to latest semver version                  | `false`                 |
+| `-major`        | Only suggest major version updates                                         | `false`                 |
+| `-minor`        | Only suggest minor version updates                                         | `false`                 |
+| `-patch`        | Only suggest patch version updates                                         | `true`                  |
+| `-exclude`      | Exclude specific services from being updated (comma-separated)             | `none`                  |
+| `-self-update`  | Download and install the latest version of `ccu`                           | `false`                 |
+| `-check-update` | Check whether a newer version of `ccu` is available, without installing it | `false`                 |
+
+## Keeping ccu up to date
+
+`ccu` can update itself:
+
+```bash
+ccu -self-update
+```
+
+It downloads the latest release, verifies it, and replaces the running binary in
+place. To only find out whether something newer exists, without installing
+anything:
+
+```bash
+ccu -check-update
+```
+
+Independently of those flags, a normal (non-interactive) run checks **at most
+once every 24 hours** whether a newer release exists and, if so, prints a single
+line to stderr — stdout stays clean, so piping `ccu`'s report somewhere is
+unaffected. The check never installs anything on its own; upgrading is always an
+explicit `ccu -self-update`.
+
+The timestamp of the last check is kept in `<user config dir>/ccu/update-check.json`
+(`%AppData%\ccu\update-check.json` on Windows, `~/.config/ccu/update-check.json`
+on Linux). Set `CCU_NO_UPDATE_CHECK=1` to disable the check entirely.
 
 ## Interactive mode
 
@@ -127,24 +156,24 @@ belong to and colour-coded by update level (major, minor, patch, digest), while 
 progress bar shows how far the scan got — results appear as the registries answer,
 so you can start selecting before the scan has finished.
 
-| Key                  | Action                                              |
-| -------------------- | --------------------------------------------------- |
-| `↑`/`↓` or `k`/`j`   | Move the selection                                  |
-| `space` or `enter`   | Toggle — select a row, or fold/unfold a file group  |
-| `a`                  | Select all updates                                  |
-| `n`                  | Select none                                         |
-| `z`                  | Fold/unfold the group under the cursor              |
-| `C` / `E`            | Collapse all / expand all groups                    |
-| `f`                  | Cycle the display filter (which rows are shown)     |
-| `t`                  | Cycle the target level for **all** rows             |
-| `T`/`→` or `←`       | Cycle the target level for the **highlighted** row  |
-| `d` or `tab`         | Toggle the detail pane                              |
-| `i`                  | Show the issues logged during the scan              |
-| `A`                  | Apply the **selected** updates                      |
-| `u`                  | Apply **only the highlighted row**                  |
-| `y` / `n`            | Answer the restart prompt                           |
-| `?`                  | Show help                                           |
-| `q`                  | Quit                                                |
+| Key                | Action                                             |
+| ------------------ | -------------------------------------------------- |
+| `↑`/`↓` or `k`/`j` | Move the selection                                 |
+| `space` or `enter` | Toggle — select a row, or fold/unfold a file group |
+| `a`                | Select all updates                                 |
+| `n`                | Select none                                        |
+| `z`                | Fold/unfold the group under the cursor             |
+| `C` / `E`          | Collapse all / expand all groups                   |
+| `f`                | Cycle the display filter (which rows are shown)    |
+| `t`                | Cycle the target level for **all** rows            |
+| `T`/`→` or `←`     | Cycle the target level for the **highlighted** row |
+| `d` or `tab`       | Toggle the detail pane                             |
+| `i`                | Show the issues logged during the scan             |
+| `A`                | Apply the **selected** updates                     |
+| `u`                | Apply **only the highlighted row**                 |
+| `y` / `n`          | Answer the restart prompt                          |
+| `?`                | Show help                                          |
+| `q`                | Quit                                               |
 
 `space`/`enter` never write anything — applying is always an explicit `A` or `u`.
 
@@ -152,8 +181,8 @@ so you can start selecting before the scan has finished.
 
 These are two different things, and the legend at the bottom names both:
 
-- **`show`** (`f`) only decides which rows are *visible*. It never changes a version.
-- **`target`** (`t`, `T`) decides which version `A` and `u` actually *write*.
+- **`show`** (`f`) only decides which rows are _visible_. It never changes a version.
+- **`target`** (`t`, `T`) decides which version `A` and `u` actually _write_.
 
 The target defaults to `major`, so out of the box `ccu -i` offers the highest
 available version, as it always has. Set it to `minor` or `patch` when you would
@@ -195,12 +224,12 @@ every build with the commit it was built from (for example `ghcr.io/vert-sh/vert
 which publishes `sha-e1c83ba` style tags). For those, `ccu` compares the image
 manifest digest instead of the version number:
 
-| In your Compose file                     | What `ccu` does                                                            |
-| ---------------------------------------- | -------------------------------------------------------------------------- |
-| `image: vert:sha-438f91a`                | Moves the tag to the one currently matching `latest`, e.g. `sha-e1c83ba`   |
-| `image: vert@sha256:abc…`                | Rewrites the digest to the one `latest` now resolves to                     |
-| `image: vert:1.2.3@sha256:abc…`          | Bumps the tag **and** the digest together, so they stay consistent          |
-| `image: vert:latest`                     | Skipped — a floating tag already resolves to the newest image               |
+| In your Compose file            | What `ccu` does                                                          |
+| ------------------------------- | ------------------------------------------------------------------------ |
+| `image: vert:sha-438f91a`       | Moves the tag to the one currently matching `latest`, e.g. `sha-e1c83ba` |
+| `image: vert@sha256:abc…`       | Rewrites the digest to the one `latest` now resolves to                  |
+| `image: vert:1.2.3@sha256:abc…` | Bumps the tag **and** the digest together, so they stay consistent       |
+| `image: vert:latest`            | Skipped — a floating tag already resolves to the newest image            |
 
 These updates are reported with the update level `digest`. Since a digest change
 has no major/minor/patch level, it is always reported and is not affected by the

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -17,6 +17,8 @@ type CCUFlags struct {
 	Minor       bool     // Update to the latest minor version
 	Patch       bool     // Update to the latest patch version
 	Version     bool     // Version of ccu
+	SelfUpdate  bool     // Download and install the latest version of ccu
+	CheckUpdate bool     // Check whether a newer version of ccu is available, without installing it
 	Exclude     []string // Directories to exclude from search
 	ExcludeStr  string   // Comma-separated list of directories to exclude from search (flag only)
 }
@@ -34,6 +36,10 @@ func Parse(version string) CCUFlags {
 	flag.BoolVar(&args.Minor, "minor", false, "Update to the latest minor version")
 	flag.BoolVar(&args.Patch, "patch", true, "Update to the latest patch version")
 	flag.BoolVar(&args.Version, "v", false, "Show version information")
+	// Unlike -v and -h below, these two are not handled here: they talk to the
+	// network and can fail, and Parse has no way to report that.
+	flag.BoolVar(&args.SelfUpdate, "self-update", false, "Download and install the latest version of ccu")
+	flag.BoolVar(&args.CheckUpdate, "check-update", false, "Check whether a newer version of ccu is available, without installing it")
 	flag.StringVar(&args.ExcludeStr, "exclude", "", "Comma-separated list of directories to exclude from search")
 
 	flag.Parse()

--- a/internal/update/notice.go
+++ b/internal/update/notice.go
@@ -1,0 +1,144 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// checkInterval is how often the passive notice refreshes its cached "latest
+// version" — at most once per this window, so ordinary scans never repeatedly
+// hit the network.
+const checkInterval = 24 * time.Hour
+
+// noticeTimeout bounds the refresh so a slow or unreachable GitHub can't delay
+// the user's command by more than this.
+const noticeTimeout = 1500 * time.Millisecond
+
+// state is the cached result of the last update check.
+type state struct {
+	LastCheck time.Time `json:"last_check"`
+	Latest    string    `json:"latest"` // latest version seen, without a leading "v"
+}
+
+// statePath returns the cache file location. It's a var so tests can redirect it
+// instead of mutating the process environment for os.UserConfigDir.
+//
+// UserConfigDir is the natural cross-platform home for this: %AppData% on
+// Windows (a first-class CI target here), ~/.config elsewhere — preferable to
+// hand-rolling ~/.ccu.
+var statePath = func() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "ccu", "update-check.json"), nil
+}
+
+func loadState() state {
+	var st state
+	path, err := statePath()
+	if err != nil {
+		return st
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return st
+	}
+	_ = json.Unmarshal(data, &st) // a corrupt cache is not a user-facing error, it just forces a fresh check
+	// The cached version is printed straight to a terminal, and the cache file is
+	// attacker-influencable at rest. Re-validate on load so terminal escape
+	// sequences can't survive a round trip through the cache.
+	if !ValidVersion(st.Latest) {
+		st.Latest = ""
+	}
+	return st
+}
+
+func saveState(st state) {
+	path, err := statePath()
+	if err != nil {
+		return
+	}
+	// 0o700/0o600: the file is per-user state, nothing else needs to read it.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return
+	}
+	data, err := json.Marshal(st)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o600) // best effort; a failed write only costs an extra check
+}
+
+// NotifyIfAvailable prints a one-line "newer version available" hint to w when
+// the cached latest version is newer than current, then refreshes the cache if
+// it's stale. The caller passes os.Stderr so piped stdout stays
+// machine-readable.
+//
+// The notice always reflects the *previously* cached check: the refresh below
+// only updates the cache for the next run. That keeps the common path off a
+// blocking network round trip while still converging within a day.
+//
+// Set CCU_NO_UPDATE_CHECK to any non-empty value to disable it entirely.
+func NotifyIfAvailable(w io.Writer, current string) {
+	// Dev builds have no meaningful "newer" release to point at, and the opt-out
+	// must short-circuit before any file or network access.
+	if os.Getenv("CCU_NO_UPDATE_CHECK") != "" || IsDevVersion(current) {
+		return
+	}
+
+	st := loadState()
+
+	// Print first, refresh second — see the doc comment.
+	if st.Latest != "" && IsNewer(st.Latest, current) {
+		fmt.Fprintf(w, "\nA newer ccu is available: %s (you have %s). Run `ccu -self-update` to upgrade.\n", st.Latest, current)
+	}
+
+	if time.Since(st.LastCheck) < checkInterval {
+		return
+	}
+	refresh(NewClient(&http.Client{Timeout: noticeTimeout}), st)
+}
+
+// refresh claims the 24h window before touching the network, so a hanging or
+// erroring endpoint doesn't make every single invocation retry the fetch. Then
+// it records the latest version for the next run.
+//
+// This still blocks the caller for up to noticeTimeout in the worst case; that
+// is the deliberate ceiling on the once-a-day path.
+func refresh(c *Client, st state) {
+	st.LastCheck = time.Now()
+	saveState(st) // claim the window up front, even if the fetch below fails
+
+	ctx, cancel := context.WithTimeout(context.Background(), noticeTimeout)
+	defer cancel()
+
+	// The fetch runs in a goroutine so ctx.Done() bounds the wait even if the
+	// client ignores the context; the buffered channel keeps it from leaking.
+	done := make(chan string, 1)
+	go func() {
+		rel, err := c.LatestRelease(ctx)
+		if err != nil {
+			close(done)
+			return
+		}
+		done <- strings.TrimPrefix(rel.Tag, "v")
+	}()
+
+	select {
+	case v, ok := <-done:
+		if ok && v != "" {
+			st.Latest = v
+			saveState(st)
+		}
+	case <-ctx.Done():
+		// Timed out; the claimed window stands and we try again tomorrow.
+	}
+}

--- a/internal/update/notice_test.go
+++ b/internal/update/notice_test.go
@@ -1,0 +1,237 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// redirectState points statePath at a temp file for the duration of the test,
+// so nothing here can read or clobber the real user config dir.
+func redirectState(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ccu", "update-check.json")
+	orig := statePath
+	statePath = func() (string, error) { return path, nil }
+	t.Cleanup(func() { statePath = orig })
+	return path
+}
+
+// seedState writes a cache file at the redirected location.
+func seedState(t *testing.T, path string, st state) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	data, err := json.Marshal(st)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+}
+
+// seedRaw writes arbitrary bytes as the cache, for corruption cases.
+func seedRaw(t *testing.T, path, contents string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+}
+
+// notifyOutput runs the notice against a fresh cache (LastCheck=now, so no
+// network is involved) and returns whatever it printed.
+func notifyOutput(t *testing.T, cached, current string) string {
+	t.Helper()
+	path := redirectState(t)
+	seedState(t, path, state{LastCheck: time.Now(), Latest: cached})
+	t.Setenv("CCU_NO_UPDATE_CHECK", "")
+
+	var buf bytes.Buffer
+	NotifyIfAvailable(&buf, current)
+	return buf.String()
+}
+
+func TestNotifyIfAvailable_CachedVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		cached  string
+		current string
+		want    string // substring expected in the output; empty means silence
+	}{
+		{name: "newer cached version prints the notice", cached: "1.4.0", current: "1.3.1", want: "1.4.0"},
+		{name: "equal cached version stays silent", cached: "1.3.1", current: "1.3.1"},
+		{name: "older cached version stays silent", cached: "1.2.0", current: "1.3.1"},
+		{name: "empty cached version stays silent", cached: "", current: "1.3.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := notifyOutput(t, tt.cached, tt.current)
+			if tt.want == "" {
+				assert.Empty(t, out)
+				return
+			}
+			assert.Contains(t, out, tt.want)
+			assert.Contains(t, out, tt.current)
+			assert.Contains(t, out, "ccu -self-update")
+		})
+	}
+}
+
+func TestNotifyIfAvailable_KillSwitchSuppressesEverything(t *testing.T) {
+	path := redirectState(t)
+	// Stale cache: without the kill switch this would both print and refresh.
+	seedState(t, path, state{LastCheck: time.Now().Add(-48 * time.Hour), Latest: "1.4.0"})
+	t.Setenv("CCU_NO_UPDATE_CHECK", "1")
+
+	var buf bytes.Buffer
+	NotifyIfAvailable(&buf, "1.3.1")
+
+	assert.Empty(t, buf.String())
+	// The window must not have been claimed either — nothing ran at all.
+	before := readState(t, path)
+	assert.True(t, before.LastCheck.Before(time.Now().Add(-24*time.Hour)))
+}
+
+func TestNotifyIfAvailable_DevVersionSuppressesEverything(t *testing.T) {
+	path := redirectState(t)
+	seedState(t, path, state{LastCheck: time.Now(), Latest: "1.4.0"})
+	t.Setenv("CCU_NO_UPDATE_CHECK", "")
+
+	var buf bytes.Buffer
+	NotifyIfAvailable(&buf, "dev")
+
+	assert.Empty(t, buf.String())
+}
+
+func TestNotifyIfAvailable_CorruptCacheIsIgnored(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{name: "not json", contents: "this is not json at all"},
+		{name: "truncated json", contents: `{"last_check": "2026-01-0`},
+		{name: "wrong types", contents: `{"last_check": 42, "latest": ["1.4.0"]}`},
+		{name: "empty file", contents: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := redirectState(t)
+			seedRaw(t, path, tt.contents)
+			t.Setenv("CCU_NO_UPDATE_CHECK", "1") // keep the refresh off the network
+
+			var buf bytes.Buffer
+			assert.NotPanics(t, func() { NotifyIfAvailable(&buf, "1.3.1") })
+			assert.Empty(t, buf.String())
+		})
+	}
+}
+
+func TestNotifyIfAvailable_RejectsEscapeSequenceInCache(t *testing.T) {
+	// A tampered cache must never reach the terminal: the stored version is
+	// re-validated on load, so an ANSI payload is dropped rather than printed.
+	out := notifyOutput(t, "9.9.9\x1b[31mowned", "1.3.1")
+	assert.Empty(t, out)
+}
+
+func TestNotifyIfAvailable_FreshCacheSkipsNetwork(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	}))
+	defer srv.Close()
+
+	path := redirectState(t)
+	seeded := state{LastCheck: time.Now().Add(-time.Hour), Latest: "1.4.0"}
+	seedState(t, path, seeded)
+	t.Setenv("CCU_NO_UPDATE_CHECK", "")
+
+	var buf bytes.Buffer
+	NotifyIfAvailable(&buf, "1.3.1")
+
+	assert.Contains(t, buf.String(), "1.4.0")
+	assert.Zero(t, atomic.LoadInt32(&hits), "a check within checkInterval must not touch the network")
+	// The window was not re-claimed, so tomorrow's run still refreshes on time.
+	assert.WithinDuration(t, seeded.LastCheck, readState(t, path).LastCheck, time.Second)
+}
+
+func TestRefresh_StoresLatestOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	}))
+	defer srv.Close()
+
+	path := redirectState(t)
+	refresh(clientFor(srv.URL), state{})
+
+	st := readState(t, path)
+	assert.Equal(t, "9.9.9", st.Latest, "the leading v is stripped before caching")
+	assert.WithinDuration(t, time.Now(), st.LastCheck, time.Minute)
+}
+
+func TestRefresh_ClaimsWindowWhenServerFails(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "server errors",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "boom", http.StatusInternalServerError)
+			},
+		},
+		{
+			name: "server hangs past noticeTimeout",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				// Unblock on client cancellation so srv.Close() can't deadlock
+				// waiting for an in-flight request.
+				<-r.Context().Done()
+			},
+		},
+		{
+			name: "server returns garbage",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("not json"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			path := redirectState(t)
+			refresh(clientFor(srv.URL), state{})
+
+			// The whole point of claiming up front: a broken endpoint still costs
+			// exactly one attempt per day, not one per invocation.
+			st := readState(t, path)
+			assert.WithinDuration(t, time.Now(), st.LastCheck, time.Minute)
+			assert.Empty(t, st.Latest, "a failed fetch must not cache a version")
+		})
+	}
+}
+
+// clientFor builds a Client aimed at a loopback test server; plain http to
+// 127.0.0.1 is permitted by the client's URL policy.
+func clientFor(base string) *Client {
+	c := NewClient(&http.Client{Timeout: noticeTimeout})
+	c.APIBase = base
+	return c
+}
+
+func readState(t *testing.T, path string) state {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var st state
+	require.NoError(t, json.Unmarshal(data, &st))
+	return st
+}

--- a/internal/update/run.go
+++ b/internal/update/run.go
@@ -1,0 +1,57 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// updateTimeout bounds the whole check-download-verify-install cycle. Generous
+// compared to the passive notice, since the user explicitly asked to update and
+// is waiting on the result rather than being interrupted by it.
+const updateTimeout = 60 * time.Second
+
+// selfUpdater is the slice of *Client that Run needs. Naming it lets the tests
+// drive every output branch without a network round-trip.
+type selfUpdater interface {
+	SelfUpdate(ctx context.Context, current string, checkOnly bool) (*Result, error)
+}
+
+// Run performs (or checks for) a self-update, writing progress to w.
+func Run(w io.Writer, current string, checkOnly bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), updateTimeout)
+	defer cancel()
+
+	return run(ctx, w, NewClient(&http.Client{Timeout: updateTimeout}), current, checkOnly)
+}
+
+// run holds the reporting logic, separated from client construction so the
+// caller of the tests can supply an updater. Errors travel back unwrapped: main
+// owns the exit code, this only decides what the user reads.
+func run(ctx context.Context, w io.Writer, u selfUpdater, current string, checkOnly bool) error {
+	// A plain check is expected to be quiet enough to script around; only the
+	// installing path announces itself before the (possibly slow) download.
+	if !checkOnly {
+		fmt.Fprintf(w, "Current version: %s. Checking for updates…\n", current)
+	}
+
+	res, err := u.SelfUpdate(ctx, current, checkOnly)
+	if err != nil {
+		return err
+	}
+
+	// SelfUpdate reports what it found even when it installed nothing, so the
+	// comparison — not res.Updated — is what tells the two apart.
+	if !IsNewer(res.Latest, res.Current) {
+		fmt.Fprintf(w, "You're on the latest version (%s).\n", res.Current)
+		return nil
+	}
+	if checkOnly {
+		fmt.Fprintf(w, "A newer version is available: %s (you have %s). Run `ccu -self-update` to upgrade.\n", res.Latest, res.Current)
+		return nil
+	}
+	fmt.Fprintf(w, "Updated ccu %s → %s.\n", res.Current, res.Latest)
+	return nil
+}

--- a/internal/update/run_test.go
+++ b/internal/update/run_test.go
@@ -1,0 +1,70 @@
+package update
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeUpdater returns a canned result, so every reporting branch can be driven
+// without reaching the network or touching the running binary.
+type fakeUpdater struct {
+	res *Result
+	err error
+
+	gotCurrent   string
+	gotCheckOnly bool
+}
+
+func (f *fakeUpdater) SelfUpdate(_ context.Context, current string, checkOnly bool) (*Result, error) {
+	f.gotCurrent, f.gotCheckOnly = current, checkOnly
+	return f.res, f.err
+}
+
+func TestRunUpToDate(t *testing.T) {
+	var buf bytes.Buffer
+	u := &fakeUpdater{res: &Result{Current: "1.2.3", Latest: "1.2.3"}}
+
+	require.NoError(t, run(context.Background(), &buf, u, "1.2.3", false))
+
+	assert.Contains(t, buf.String(), "Current version: 1.2.3. Checking for updates…")
+	assert.Contains(t, buf.String(), "You're on the latest version (1.2.3).")
+}
+
+func TestRunCheckOnlyNewer(t *testing.T) {
+	var buf bytes.Buffer
+	u := &fakeUpdater{res: &Result{Current: "1.2.3", Latest: "1.3.0"}}
+
+	require.NoError(t, run(context.Background(), &buf, u, "1.2.3", true))
+
+	assert.True(t, u.gotCheckOnly, "checkOnly must reach SelfUpdate, or a check would install")
+	// A check announces nothing up front — the verdict is the entire output.
+	assert.Equal(t, "A newer version is available: 1.3.0 (you have 1.2.3). Run `ccu -self-update` to upgrade.\n", buf.String())
+}
+
+func TestRunUpdated(t *testing.T) {
+	var buf bytes.Buffer
+	u := &fakeUpdater{res: &Result{Current: "1.2.3", Latest: "1.3.0", Updated: true}}
+
+	require.NoError(t, run(context.Background(), &buf, u, "1.2.3", false))
+
+	assert.False(t, u.gotCheckOnly)
+	assert.Equal(t, "1.2.3", u.gotCurrent)
+	assert.Contains(t, buf.String(), "Updated ccu 1.2.3 → 1.3.0.")
+}
+
+// A failed lookup must surface unchanged: main turns it into the exit code, so
+// wrapping or swallowing it here would hide why the update did not happen.
+func TestRunPropagatesError(t *testing.T) {
+	var buf bytes.Buffer
+	want := errors.New("release lookup failed")
+
+	err := run(context.Background(), &buf, &fakeUpdater{err: want}, "1.2.3", false)
+
+	assert.Same(t, want, err)
+	assert.NotContains(t, buf.String(), "Updated ccu")
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,464 @@
+// Package update handles self-updating the ccu binary from GitHub Releases.
+//
+// The release pipeline publishes one RAW, UNCOMPRESSED binary per platform,
+// named ccu-<goos>-<goarch>(.exe), plus a sha256sum-format checksums file
+// ccu_<version>_checksums.txt (see .github/workflows/release.yml). There is no
+// archive to unpack: the downloaded bytes are the executable, so the download is
+// verified against the checksums file and then swapped straight into place.
+//
+// The trust chain is therefore three links, and every one of them has to hold:
+// https to a pinned GitHub host authenticates the channel, the checksums file
+// authenticates the binary, and an atomic same-directory rename installs it.
+// ccu publishes no detached signature, which makes the host pinning load-bearing
+// rather than defence in depth — a checksum fetched over an attacker-controlled
+// channel vouches for nothing.
+//
+// Everything that touches the network goes through Client so tests can point at
+// a local httptest server; checksum verification and asset naming are pure
+// functions.
+//
+// Note: internal/version.go at the repo root is UNRELATED to this package's
+// version helpers — it compares Docker image tags, not ccu's own release
+// versions.
+package update
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Repo coordinates for the published releases, kept here so every caller points
+// at the same place.
+const (
+	repoOwner = "Padi2312"
+	repoName  = "compose-check-updates"
+)
+
+// userAgent identifies this client to GitHub; the API rejects requests without
+// a User-Agent outright.
+const userAgent = "ccu-updater"
+
+// maxAsset caps how many bytes we accept for the release binary so a hostile or
+// corrupt response can't exhaust memory. Exceeding it is always an error, never
+// a silent truncation: a truncated binary written over the user's working ccu
+// would leave them with an install that cannot run. Release binaries are a few
+// MB. A var only so tests can shrink it.
+var maxAsset = int64(64 << 20) // 64 MiB
+
+// maxChecksums is far tighter than maxAsset: a genuine checksums file is a few
+// hundred bytes, and there is no reason to buffer megabytes of "checksums" a
+// hostile asset serves up.
+const maxChecksums = int64(1 << 20) // 1 MiB
+
+// Asset is one downloadable file attached to a release.
+type Asset struct {
+	Name string `json:"name"`
+	URL  string `json:"browser_download_url"`
+}
+
+// Release is the slice of the GitHub release payload we care about.
+type Release struct {
+	Tag    string  `json:"tag_name"`
+	Assets []Asset `json:"assets"`
+}
+
+// Result reports the outcome of an update attempt.
+type Result struct {
+	Current string // version before the attempt
+	Latest  string // latest available version
+	Updated bool   // whether the binary was actually replaced
+	ExePath string // the binary that was (or would be) replaced
+}
+
+// Client talks to the GitHub Releases API. The zero value is not usable; use
+// NewClient. APIBase and HTTP are overridable in tests.
+type Client struct {
+	HTTP    *http.Client
+	APIBase string // e.g. "https://api.github.com"
+	Owner   string
+	Repo    string
+}
+
+// NewClient returns a Client pointed at github.com with the given HTTP client
+// (nil gets a fresh client with a sane timeout — never http.DefaultClient, which
+// has no timeout and is a shared global we must not mutate).
+//
+// The client gets a redirect policy that re-applies allowedURL on every hop.
+// Checking only the initial URL would be pointless: GitHub's asset URLs redirect
+// to the CDN, so an attacker who can influence a hop could walk the download off
+// a GitHub host entirely while the first URL still looked fine.
+func NewClient(hc *http.Client) *Client {
+	if hc == nil {
+		hc = &http.Client{Timeout: 30 * time.Second}
+	}
+	if hc.CheckRedirect == nil {
+		hc.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			return allowedURL(req.URL.String())
+		}
+	}
+	return &Client{HTTP: hc, APIBase: "https://api.github.com", Owner: repoOwner, Repo: repoName}
+}
+
+// allowedURL rejects any URL that isn't https to a GitHub-controlled host.
+// Release metadata — including asset URLs — is input, not truth: following a
+// plain-http URL (or a redirect hop onto one) would let an on-path attacker
+// substitute both the binary and the checksums file that vouches for it, making
+// verification meaningless. Pinning the host matters independently: a tampered
+// release must not be able to point every updating client at an arbitrary
+// server, which would leak who runs ccu to an attacker-chosen host and turn
+// clients into traffic generators. Plain http is tolerated only for loopback so
+// tests can run a local httptest server, which never listens on a routable
+// address. The error deliberately doesn't echo the URL: it's untrusted bytes
+// that would otherwise land on the user's terminal.
+func allowedURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("release asset URL is unparsable")
+	}
+	switch {
+	case u.Scheme == "https" && isGitHubHost(u.Hostname()):
+		return nil
+	case u.Scheme == "https":
+		return fmt.Errorf("refusing to download a release asset from a non-GitHub host")
+	case u.Scheme == "http" && isLoopback(u.Hostname()):
+		return nil
+	}
+	return fmt.Errorf("refusing to download a release asset over a non-https URL")
+}
+
+// isGitHubHost reports whether host is one GitHub serves releases from: the API,
+// the release download path on github.com, and the *.githubusercontent.com CDN
+// hosts those downloads redirect to. Matching is on whole labels — a lookalike
+// like "evilgithubusercontent.com" or "github.com.evil.example" must not pass.
+func isGitHubHost(host string) bool {
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+	switch host {
+	case "github.com", "api.github.com":
+		return true
+	}
+	return strings.HasSuffix(host, ".githubusercontent.com")
+}
+
+// isLoopback reports whether host is localhost or a loopback IP.
+func isLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// LatestRelease fetches the latest non-prerelease, non-draft release. GitHub's
+// /releases/latest endpoint already excludes both.
+func (c *Client) LatestRelease(ctx context.Context) (*Release, error) {
+	u := fmt.Sprintf("%s/repos/%s/%s/releases/latest", strings.TrimRight(c.APIBase, "/"), c.Owner, c.Repo)
+	// APIBase is overridable, so it gets the same scrutiny as an asset URL.
+	if err := allowedURL(u); err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		// StatusCode, not Status: the status line carries server-supplied text
+		// and this message is printed to the user's terminal.
+		return nil, fmt.Errorf("github returned HTTP %d", resp.StatusCode)
+	}
+	var rel Release
+	// Capped even though this is GitHub: an unbounded decode off the network is
+	// a memory-exhaustion primitive regardless of who is on the other end.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decoding release: %w", err)
+	}
+	// The tag is untrusted input that flows into terminal output and into asset
+	// file names we then match against — reject anything that isn't a clean
+	// version (terminal escapes, path separators, absurd lengths) at ingress,
+	// before it can go anywhere.
+	if !ValidVersion(strings.TrimPrefix(rel.Tag, "v")) {
+		return nil, fmt.Errorf("release tag is not a plausible version — refusing it")
+	}
+	return &rel, nil
+}
+
+// download fetches an asset into memory. It refuses URLs that fail allowedURL
+// (the asset URL comes from untrusted release metadata) and errors — rather than
+// silently truncating — when the body exceeds limit. what names the asset in
+// errors, since the URL itself is untrusted bytes we won't echo to the terminal.
+func (c *Client) download(ctx context.Context, rawURL, what string, limit int64) ([]byte, error) {
+	if err := allowedURL(rawURL); err != nil {
+		return nil, fmt.Errorf("%s: %w", what, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("downloading %s: HTTP %d", what, resp.StatusCode)
+	}
+	// limit+1 so an over-limit body is detectable: reading exactly limit bytes
+	// can't distinguish "fits exactly" from "was cut off".
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("%s exceeds its %d-byte size limit — refusing a truncated install", what, limit)
+	}
+	return data, nil
+}
+
+// BinaryAssetName is the release asset name for a platform, matching what the
+// release workflow uploads: raw binaries, not archives, because the README's
+// install one-liners tell users to download exactly these names.
+func BinaryAssetName(goos, goarch string) string {
+	name := fmt.Sprintf("ccu-%s-%s", goos, goarch)
+	if goos == "windows" {
+		name += ".exe"
+	}
+	return name
+}
+
+// ChecksumsName is the checksums file name for a version.
+func ChecksumsName(version string) string {
+	return fmt.Sprintf("ccu_%s_checksums.txt", version)
+}
+
+// findAsset returns the asset with the given name, or an error naming what was
+// looked for (which is our own string, not release-supplied text). A miss most
+// often means the release simply didn't build for this platform.
+func findAsset(assets []Asset, name string) (Asset, error) {
+	for _, a := range assets {
+		if a.Name == name {
+			return a, nil
+		}
+	}
+	return Asset{}, fmt.Errorf("release has no asset %q (this platform may not be published)", name)
+}
+
+// verifyChecksum confirms bin's SHA-256 appears against name in a
+// sha256sum-format checksums file ("<hex>  <name>" per line).
+func verifyChecksum(bin []byte, name string, checksums []byte) error {
+	sum := sha256.Sum256(bin)
+	want := hex.EncodeToString(sum[:])
+	for _, line := range strings.Split(string(checksums), "\n") {
+		fields := strings.Fields(line)
+		// Only well-formed lines (64 hex chars + name) can match at all. This is
+		// also what keeps the mismatch message below safe to print: the checksums
+		// file is untrusted, and a non-hex "hash" could otherwise smuggle
+		// terminal escape sequences into the error output.
+		if len(fields) != 2 || !isHex64(fields[0]) {
+			continue
+		}
+		// sha256sum prefixes the name with "*" in binary mode; tolerate it.
+		if strings.TrimPrefix(fields[1], "*") == name {
+			// EqualFold: sha256sum emits lowercase, but other tools emit upper.
+			if strings.EqualFold(fields[0], want) {
+				return nil
+			}
+			// Distinct from the "not listed" case below: a mismatch means the
+			// bytes are wrong (tampering or corruption), while a missing entry
+			// means the release is incomplete. Different causes, different fixes.
+			return fmt.Errorf("checksum mismatch for %q: got %s, want %s", name, want, strings.ToLower(fields[0]))
+		}
+	}
+	return fmt.Errorf("no checksum listed for %q", name)
+}
+
+// isHex64 reports whether s is exactly 64 hexadecimal characters (a SHA-256).
+func isHex64(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+// executablePath resolves the running binary to a real, symlink-free path so the
+// swap targets the actual file rather than a symlink pointing at it — replacing
+// the symlink would leave the real binary stale and the link dangling. It's a
+// var so tests can point the swap at a throwaway file.
+var executablePath = func() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(exe)
+}
+
+// replaceExecutable atomically swaps the file at exePath for newBin.
+//
+// The new binary is written to a temp file in the SAME directory as the target
+// so the final rename stays on one filesystem: a cross-device rename is not
+// atomic (it degrades to copy-then-delete, or fails outright), and a partially
+// copied executable is exactly the outcome this whole function exists to avoid.
+//
+// On Windows a running .exe cannot be deleted or overwritten, but it CAN be
+// renamed, so the current file is moved aside to "<exe>.old" first; that
+// leftover is cleaned up on the next run (see CleanupLeftovers).
+func replaceExecutable(exePath string, newBin []byte) error {
+	dir := filepath.Dir(exePath)
+	tmp, err := os.CreateTemp(dir, ".ccu-update-*")
+	if err != nil {
+		return fmt.Errorf("cannot write to %q (%w) — reinstall ccu or run with sufficient permissions", dir, err)
+	}
+	tmpName := tmp.Name()
+	// Clean up the temp file on every failure path before the final rename
+	// succeeds, so a failed update doesn't litter the install directory.
+	success := false
+	defer func() {
+		if !success {
+			os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(newBin); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing the new binary: %w", err)
+	}
+	// Close before chmod/rename: on Windows an open handle blocks the rename,
+	// and the write isn't guaranteed flushed until Close returns.
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("writing the new binary: %w", err)
+	}
+	// CreateTemp makes the file 0600; without this the installed binary would
+	// not be executable (and would not be usable by other users on Unix).
+	if err := os.Chmod(tmpName, 0o755); err != nil {
+		return fmt.Errorf("making the new binary executable: %w", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		old := exePath + ".old"
+		os.Remove(old) // a stale one from a previous update would block the rename
+		if err := os.Rename(exePath, old); err != nil {
+			return fmt.Errorf("cannot move the current binary aside (%w) — is another ccu running, or is %q read-only?", err, exePath)
+		}
+		if err := os.Rename(tmpName, exePath); err != nil {
+			// Roll back: without this the user is left with NO binary at all —
+			// strictly worse than a failed update.
+			os.Rename(old, exePath)
+			return fmt.Errorf("cannot install the new binary (%w) — reinstall ccu or run with sufficient permissions", err)
+		}
+	} else if err := os.Rename(tmpName, exePath); err != nil {
+		return fmt.Errorf("cannot replace %q (%w) — reinstall ccu or run with sufficient permissions", exePath, err)
+	}
+
+	success = true
+	return nil
+}
+
+// CleanupLeftovers best-effort removes the "<exe>.old" file left behind by a
+// prior Windows self-update. Called once at startup; every error is ignored on
+// purpose — there is nothing the user could do about it, and a leftover file is
+// harmless (the next update retries the removal anyway).
+func CleanupLeftovers() {
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if exe, err = filepath.EvalSymlinks(exe); err != nil {
+		return
+	}
+	os.Remove(exe + ".old")
+}
+
+// SelfUpdate checks for a newer release and, unless checkOnly, downloads,
+// verifies, and installs it in place of the running binary. current is the
+// running version (without a leading "v").
+//
+// The updated binary is NOT re-executed: the caller's process keeps running the
+// old code it already loaded, which is both simpler and safer than re-exec'ing
+// mid-command with arguments that may no longer mean the same thing.
+func (c *Client) SelfUpdate(ctx context.Context, current string, checkOnly bool) (*Result, error) {
+	if IsDevVersion(current) {
+		// A source build has no release to compare against, and silently
+		// overwriting it with a published binary would discard the user's build.
+		return nil, fmt.Errorf("this is a %q build, not an installed release — build from source or download a release binary to get updates", current)
+	}
+
+	rel, err := c.LatestRelease(ctx)
+	if err != nil {
+		return nil, err
+	}
+	latest := strings.TrimPrefix(rel.Tag, "v")
+	res := &Result{Current: current, Latest: latest}
+
+	if !IsNewer(latest, current) {
+		return res, nil
+	}
+	// Return before touching the network again: --check must never download,
+	// let alone write anything.
+	if checkOnly {
+		return res, nil
+	}
+
+	exe, err := executablePath()
+	if err != nil {
+		return nil, fmt.Errorf("cannot locate the running binary: %w", err)
+	}
+	res.ExePath = exe
+
+	binName := BinaryAssetName(runtime.GOOS, runtime.GOARCH)
+	binAsset, err := findAsset(rel.Assets, binName)
+	if err != nil {
+		return nil, err
+	}
+	sumsAsset, err := findAsset(rel.Assets, ChecksumsName(latest))
+	if err != nil {
+		// Without checksums nothing authenticates the binary, so this is fatal
+		// rather than a warning we could shrug off.
+		return nil, fmt.Errorf("release has no checksums file: %w — refusing to update", err)
+	}
+
+	// The asset is the executable itself — no archive to unpack.
+	bin, err := c.download(ctx, binAsset.URL, "release binary", maxAsset)
+	if err != nil {
+		return nil, err
+	}
+	sums, err := c.download(ctx, sumsAsset.URL, "checksums file", maxChecksums)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyChecksum(bin, binName, sums); err != nil {
+		return nil, err
+	}
+	// A zero-byte asset would checksum fine against a matching entry, yet
+	// installing it bricks the user's ccu just as thoroughly as a truncated one.
+	if len(bin) == 0 {
+		return nil, fmt.Errorf("release binary %q is empty — refusing to install it", binName)
+	}
+	if err := replaceExecutable(exe, bin); err != nil {
+		return nil, err
+	}
+
+	res.Updated = true
+	return res, nil
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,443 @@
+package update
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sum returns the sha256sum-style hex digest of b.
+func sum(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+// releaseServer stands in for GitHub: it serves /releases/latest plus one asset
+// per entry in assets. Asset URLs point back at the same server, which listens
+// on loopback — the only case where allowedURL tolerates plain http.
+func releaseServer(t *testing.T, tag string, assets map[string][]byte) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		var items []string
+		for name := range assets {
+			items = append(items, fmt.Sprintf(`{"name":%q,"browser_download_url":"%s/dl/%s"}`, name, srv.URL, name))
+		}
+		fmt.Fprintf(w, `{"tag_name":%q,"assets":[%s]}`, tag, strings.Join(items, ","))
+	})
+	mux.HandleFunc("/dl/", func(w http.ResponseWriter, r *http.Request) {
+		body, ok := assets[strings.TrimPrefix(r.URL.Path, "/dl/")]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Write(body)
+	})
+	return srv
+}
+
+// updateClient returns a Client aimed at srv. Named distinctly from notice_test.go's
+// clientFor, which takes a base URL string.
+func updateClient(srv *httptest.Server) *Client {
+	c := NewClient(nil)
+	c.APIBase = srv.URL
+	return c
+}
+
+// fakeExe points executablePath at a throwaway file for the duration of the
+// test, so the binary swap can be exercised for real without touching the test
+// runner's own executable (which the OS would not let us replace anyway).
+func fakeExe(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ccu-fake.exe")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	// EvalSymlinks: on macOS t.TempDir() lives under a symlinked /var, and the
+	// production path resolves symlinks, so the expected path must too.
+	resolved, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+
+	orig := executablePath
+	executablePath = func() (string, error) { return resolved, nil }
+	t.Cleanup(func() { executablePath = orig })
+	return resolved
+}
+
+func TestBinaryAssetName(t *testing.T) {
+	tests := []struct {
+		name         string
+		goos, goarch string
+		want         string
+	}{
+		{"linux amd64", "linux", "amd64", "ccu-linux-amd64"},
+		{"linux arm64", "linux", "arm64", "ccu-linux-arm64"},
+		{"darwin arm64", "darwin", "arm64", "ccu-darwin-arm64"},
+		{"windows gets .exe", "windows", "amd64", "ccu-windows-amd64.exe"},
+		{"windows 386", "windows", "386", "ccu-windows-386.exe"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, BinaryAssetName(tt.goos, tt.goarch))
+		})
+	}
+}
+
+func TestChecksumsName(t *testing.T) {
+	assert.Equal(t, "ccu_0.4.1_checksums.txt", ChecksumsName("0.4.1"))
+	assert.Equal(t, "ccu_1.0.0-beta.1_checksums.txt", ChecksumsName("1.0.0-beta.1"))
+}
+
+func TestAllowedURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string // substring; "" means allowed
+	}{
+		{"github api over https", "https://api.github.com/repos/x/y", ""},
+		{"github.com over https", "https://github.com/o/r/releases/download/v1/ccu", ""},
+		{"cdn over https", "https://objects.githubusercontent.com/blob", ""},
+		{"trailing dot host", "https://github.com./o/r", ""},
+		{"loopback http for tests", "http://127.0.0.1:8080/dl", ""},
+		{"localhost http for tests", "http://localhost:8080/dl", ""},
+		{"ipv6 loopback http", "http://[::1]:8080/dl", ""},
+		{"non-github https", "https://evil.example/ccu", "non-GitHub host"},
+		{"lookalike suffix", "https://evilgithubusercontent.com/x", "non-GitHub host"},
+		{"lookalike prefix", "https://github.com.evil.example/x", "non-GitHub host"},
+		{"plain http to github", "http://github.com/o/r", "non-https"},
+		{"non-loopback http", "http://192.0.2.1/ccu", "non-https"},
+		{"file scheme", "file:///etc/passwd", "non-https"},
+		{"unparsable", "://nope", "unparsable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := allowedURL(tt.url)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			// The untrusted URL must never be echoed back to the terminal.
+			assert.NotContains(t, err.Error(), "evil")
+		})
+	}
+}
+
+func TestVerifyChecksum(t *testing.T) {
+	bin := []byte("binary contents")
+	good := sum(bin)
+
+	tests := []struct {
+		name      string
+		checksums string
+		wantErr   string
+	}{
+		{"match", good + "  ccu-linux-amd64\n", ""},
+		{"match with binary-mode star", good + " *ccu-linux-amd64\n", ""},
+		{"match uppercase hex", strings.ToUpper(good) + "  ccu-linux-amd64\n", ""},
+		{"match among other entries", "0\n" + sum([]byte("x")) + "  ccu-darwin-arm64\n" + good + "  ccu-linux-amd64\n", ""},
+		{"mismatch", sum([]byte("other")) + "  ccu-linux-amd64\n", "checksum mismatch"},
+		{"name absent", good + "  ccu-darwin-arm64\n", "no checksum listed"},
+		{"empty file", "", "no checksum listed"},
+		{"malformed lines ignored", "notahash ccu-linux-amd64\nshort  ccu-linux-amd64\n", "no checksum listed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyChecksum(bin, "ccu-linux-amd64", []byte(tt.checksums))
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// A non-hex "hash" must not be able to smuggle terminal escapes into the error.
+func TestVerifyChecksum_RejectsEscapeSmuggling(t *testing.T) {
+	bin := []byte("binary contents")
+	line := "\x1b[31mPWNED\x1b[0m  ccu-linux-amd64\n"
+	err := verifyChecksum(bin, "ccu-linux-amd64", []byte(line))
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "\x1b")
+	assert.NotContains(t, err.Error(), "PWNED")
+}
+
+func TestFindAsset(t *testing.T) {
+	assets := []Asset{{Name: "ccu-linux-amd64", URL: "u1"}, {Name: "sums.txt", URL: "u2"}}
+
+	got, err := findAsset(assets, "sums.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "u2", got.URL)
+
+	_, err = findAsset(assets, "ccu-plan9-amd64")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ccu-plan9-amd64")
+}
+
+func TestLatestRelease(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		srv := releaseServer(t, "v1.2.3", map[string][]byte{"ccu-linux-amd64": []byte("bin")})
+		rel, err := updateClient(srv).LatestRelease(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "v1.2.3", rel.Tag)
+		require.Len(t, rel.Assets, 1)
+		assert.Equal(t, "ccu-linux-amd64", rel.Assets[0].Name)
+		assert.Contains(t, rel.Assets[0].URL, "/dl/ccu-linux-amd64")
+	})
+
+	t.Run("sends the API headers github requires", func(t *testing.T) {
+		var accept, ua string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			accept, ua = r.Header.Get("Accept"), r.Header.Get("User-Agent")
+			fmt.Fprint(w, `{"tag_name":"v1.0.0"}`)
+		}))
+		defer srv.Close()
+		_, err := updateClient(srv).LatestRelease(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "application/vnd.github+json", accept)
+		assert.Equal(t, "ccu-updater", ua)
+	})
+
+	t.Run("non-200 reports the code, never the server's status text", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// A hostile status line: it must not reach the user's terminal.
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer srv.Close()
+		_, err := updateClient(srv).LatestRelease(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "403")
+		assert.NotContains(t, err.Error(), "Forbidden")
+	})
+
+	t.Run("rejects an implausible tag", func(t *testing.T) {
+		for _, tag := range []string{
+			`v\u001b[31mnope`, // a terminal escape smuggled through the tag
+			`../../etc/passwd`,
+			`v` + strings.Repeat("9", 200), // absurd length
+			``,
+		} {
+			// The tag goes into the body verbatim rather than through
+			// releaseServer's %q, so the escape case can carry a JSON-level
+			// unicode escape. %q would render an ESC as a Go hex escape, which
+			// JSON does not understand, and a raw ESC byte is rejected by the
+			// decoder before ValidVersion ever sees it - either way the test
+			// would pass for the wrong reason.
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, `{"tag_name":"%s","assets":[]}`, tag)
+			}))
+			_, err := updateClient(srv).LatestRelease(context.Background())
+			srv.Close()
+			require.Error(t, err, "tag %q should be refused", tag)
+			assert.Contains(t, err.Error(), "not a plausible version")
+		}
+	})
+
+	t.Run("refuses a non-GitHub API base", func(t *testing.T) {
+		c := NewClient(nil)
+		c.APIBase = "https://evil.example"
+		_, err := c.LatestRelease(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-GitHub host")
+	})
+}
+
+func TestSelfUpdate_DevVersionRefused(t *testing.T) {
+	for _, v := range []string{"", "dev", "(devel)"} {
+		t.Run(fmt.Sprintf("version %q", v), func(t *testing.T) {
+			// No server: it must refuse before making any request.
+			_, err := NewClient(nil).SelfUpdate(context.Background(), v, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not an installed release")
+		})
+	}
+}
+
+func TestSelfUpdate_AlreadyCurrent(t *testing.T) {
+	srv := releaseServer(t, "v1.0.0", nil)
+	res, err := updateClient(srv).SelfUpdate(context.Background(), "1.0.0", false)
+	require.NoError(t, err)
+	assert.False(t, res.Updated)
+	assert.Equal(t, "1.0.0", res.Current)
+	assert.Equal(t, "1.0.0", res.Latest)
+	assert.Empty(t, res.ExePath, "nothing should have been located, let alone replaced")
+}
+
+func TestSelfUpdate_CheckOnlyDownloadsNothing(t *testing.T) {
+	exe := fakeExe(t, "old binary")
+	downloads := 0
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"tag_name":"v2.0.0","assets":[{"name":"any","browser_download_url":"%s/dl/any"}]}`, srv.URL)
+	})
+	mux.HandleFunc("/dl/", func(w http.ResponseWriter, r *http.Request) { downloads++ })
+
+	res, err := updateClient(srv).SelfUpdate(context.Background(), "1.0.0", true)
+	require.NoError(t, err)
+	assert.False(t, res.Updated)
+	assert.Equal(t, "2.0.0", res.Latest)
+	assert.Zero(t, downloads, "checkOnly must not fetch any asset")
+
+	data, err := os.ReadFile(exe)
+	require.NoError(t, err)
+	assert.Equal(t, "old binary", string(data), "checkOnly must not touch the binary")
+}
+
+func TestSelfUpdate_ReplacesTheBinary(t *testing.T) {
+	exe := fakeExe(t, "old binary")
+	newBin := []byte("brand new binary contents")
+	binName := BinaryAssetName(runtime.GOOS, runtime.GOARCH)
+	srv := releaseServer(t, "v2.0.0", map[string][]byte{
+		binName:                newBin,
+		ChecksumsName("2.0.0"): []byte(sum(newBin) + "  " + binName + "\n"),
+	})
+
+	res, err := updateClient(srv).SelfUpdate(context.Background(), "1.0.0", false)
+	require.NoError(t, err)
+	assert.True(t, res.Updated)
+	assert.Equal(t, "2.0.0", res.Latest)
+	assert.Equal(t, exe, res.ExePath)
+
+	got, err := os.ReadFile(exe)
+	require.NoError(t, err)
+	assert.Equal(t, newBin, got)
+
+	// No temp file may be left behind in the install directory.
+	entries, err := os.ReadDir(filepath.Dir(exe))
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasPrefix(e.Name(), ".ccu-update-"), "leftover temp file %s", e.Name())
+	}
+}
+
+func TestSelfUpdate_ChecksumMismatchLeavesBinaryAlone(t *testing.T) {
+	exe := fakeExe(t, "old binary")
+	binName := BinaryAssetName(runtime.GOOS, runtime.GOARCH)
+	srv := releaseServer(t, "v2.0.0", map[string][]byte{
+		binName: []byte("tampered payload"),
+		// A checksum for something else entirely.
+		ChecksumsName("2.0.0"): []byte(sum([]byte("the real binary")) + "  " + binName + "\n"),
+	})
+
+	res, err := updateClient(srv).SelfUpdate(context.Background(), "1.0.0", false)
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "checksum mismatch")
+
+	got, err := os.ReadFile(exe)
+	require.NoError(t, err)
+	assert.Equal(t, "old binary", string(got), "a failed verification must not touch the installed binary")
+}
+
+func TestSelfUpdate_MissingChecksumsRefused(t *testing.T) {
+	fakeExe(t, "old binary")
+	binName := BinaryAssetName(runtime.GOOS, runtime.GOARCH)
+	srv := releaseServer(t, "v2.0.0", map[string][]byte{binName: []byte("payload")})
+
+	_, err := updateClient(srv).SelfUpdate(context.Background(), "1.0.0", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksums")
+}
+
+func TestSelfUpdate_MissingPlatformAssetRefused(t *testing.T) {
+	fakeExe(t, "old binary")
+	srv := releaseServer(t, "v2.0.0", map[string][]byte{"ccu-plan9-mips": []byte("payload")})
+
+	_, err := updateClient(srv).SelfUpdate(context.Background(), "1.0.0", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), BinaryAssetName(runtime.GOOS, runtime.GOARCH))
+}
+
+func TestSelfUpdate_OversizeAssetRefused(t *testing.T) {
+	exe := fakeExe(t, "old binary")
+	// Shrink the cap rather than serving 64 MiB.
+	orig := maxAsset
+	maxAsset = 8
+	t.Cleanup(func() { maxAsset = orig })
+
+	big := []byte("far more than eight bytes")
+	binName := BinaryAssetName(runtime.GOOS, runtime.GOARCH)
+	srv := releaseServer(t, "v2.0.0", map[string][]byte{
+		binName:                big,
+		ChecksumsName("2.0.0"): []byte(sum(big) + "  " + binName + "\n"),
+	})
+
+	_, err := updateClient(srv).SelfUpdate(context.Background(), "1.0.0", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "size limit")
+	// The point of erroring instead of truncating: the install survives intact.
+	got, err := os.ReadFile(exe)
+	require.NoError(t, err)
+	assert.Equal(t, "old binary", string(got))
+}
+
+func TestSelfUpdate_NonGitHubAssetURLRefused(t *testing.T) {
+	fakeExe(t, "old binary")
+	binName := BinaryAssetName(runtime.GOOS, runtime.GOARCH)
+	// A tampered release whose asset URL points off-host: the metadata is input,
+	// not truth, so the download must be refused even though the API response
+	// itself came from a "trusted" server.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"tag_name":"v2.0.0","assets":[{"name":%q,"browser_download_url":"https://evil.example/ccu"},{"name":%q,"browser_download_url":"https://evil.example/sums"}]}`,
+			binName, ChecksumsName("2.0.0"))
+	}))
+	defer srv.Close()
+
+	_, err := updateClient(srv).SelfUpdate(context.Background(), "1.0.0", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-GitHub host")
+	assert.NotContains(t, err.Error(), "evil.example")
+}
+
+func TestReplaceExecutable(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "ccu.exe")
+	require.NoError(t, os.WriteFile(exe, []byte("old"), 0o755))
+
+	require.NoError(t, replaceExecutable(exe, []byte("new")))
+	got, err := os.ReadFile(exe)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+
+	if runtime.GOOS == "windows" {
+		// The old binary is moved aside rather than deleted, because a running
+		// .exe cannot be removed on Windows.
+		assert.FileExists(t, exe+".old")
+	} else {
+		// Only meaningful off Windows, where the mode bits are enforced.
+		info, err := os.Stat(exe)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	}
+}
+
+func TestReplaceExecutable_MissingDirectoryLeavesNothingBehind(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist", "ccu.exe")
+	err := replaceExecutable(missing, []byte("new"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permissions")
+	assert.NoFileExists(t, missing)
+}
+
+func TestCleanupLeftovers_IsSafeToCall(t *testing.T) {
+	// The running test binary has no ".old" sibling; this must be a silent
+	// no-op rather than a panic or an error the caller has to handle.
+	assert.NotPanics(t, CleanupLeftovers)
+}

--- a/internal/update/version.go
+++ b/internal/update/version.go
@@ -1,0 +1,245 @@
+package update
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// maxVersionLen bounds how much untrusted version text we are willing to carry
+// around. It mirrors the `^[0-9][0-9A-Za-z.+-]{0,63}$` bound the release
+// workflow applies (see .github/workflows/release.yml), so a string this
+// binary accepts is exactly a string the release pipeline could have produced.
+const maxVersionLen = 64
+
+// devVersions are the values the version stamp takes when the binary was not
+// built by the release pipeline: "" when -ldflags -X was never applied, and
+// "dev"/"(devel)" for local `go build`/`go install` builds.
+var devVersions = map[string]struct{}{
+	"":        {},
+	"dev":     {},
+	"(devel)": {},
+}
+
+// IsNewer reports whether latest is strictly newer than current.
+//
+// Two deliberate refusals live here:
+//
+// A dev build is never considered "behind" a release. Someone running a
+// locally built binary has a working tree that is usually *ahead* of the last
+// tag, and nagging them to "update" would replace their own build with an
+// older released one.
+//
+// Only a strictly greater version qualifies, which makes downgrades
+// impossible. That is the mitigation for a rollback/freeze attack: an attacker
+// who controls the network can withhold new releases and stall a user on the
+// version they already run, but cannot serve an older, known-vulnerable
+// release and have this code offer it as an "update".
+func IsNewer(latest, current string) bool {
+	if IsDevVersion(current) {
+		return false
+	}
+	return CompareVersions(latest, current) > 0
+}
+
+// CompareVersions returns -1 if a sorts before b, +1 if a sorts after b, and 0
+// if they have equal precedence.
+//
+// Precedence is standard semver: a leading "v" is tolerated, "+build" metadata
+// is ignored, missing core fields default to 0 ("1.2" == "1.2.0"), a release
+// outranks any pre-release of the same core, and pre-release identifiers are
+// compared dot-wise.
+//
+// The comparison is delegated to Masterminds/semver, the same library
+// internal/version.go already uses for Docker image tags, so ccu's own version
+// ordering cannot drift from the ordering it reports for everything else.
+// Inputs the library rejects fall back to a tolerant hand-rolled comparison,
+// and anything that fallback cannot make sense of compares equal rather than
+// greater — a malformed tag arriving off the network must never be able to
+// trigger an update, and must never panic.
+func CompareVersions(a, b string) int {
+	va, errA := semver.NewVersion(normalize(a))
+	vb, errB := semver.NewVersion(normalize(b))
+	if errA == nil && errB == nil {
+		return va.Compare(vb)
+	}
+	return compareLoose(a, b)
+}
+
+// IsDevVersion reports whether v is an unstamped or locally built binary
+// rather than a released one. Callers use it to stay silent instead of
+// comparing a meaningless version against the latest release.
+func IsDevVersion(v string) bool {
+	_, ok := devVersions[strings.ToLower(strings.TrimSpace(v))]
+	return ok
+}
+
+// ValidVersion reports whether v is a plausible version string.
+//
+// This is an ingress guard, not a semver parser. Version strings reach us from
+// the GitHub API — untrusted input — and are then printed to a terminal,
+// written into a cache file, and spliced into downloaded asset file names. The
+// charset below is what makes each of those safe:
+//
+//   - a leading digit and a [0-9A-Za-z.+-] body exclude ESC, so a crafted tag
+//     cannot smuggle ANSI/terminal escape sequences into our output (which can
+//     rewrite the screen or, on some terminals, stuff the input buffer);
+//   - excluding "/" and "\" keeps path separators — and therefore "../"
+//     traversal — out of any file name we build from a version;
+//   - the length bound keeps a multi-megabyte "version" out of the cache file
+//     and off the screen.
+//
+// It intentionally rejects a leading "v": callers normalize the prefix away
+// before validating, so exactly one representation is ever stored or rendered.
+// This mirrors the `^[0-9][0-9A-Za-z.+-]{0,63}$` check the release workflow
+// applies when cutting a release, so both ends of the pipeline agree on what a
+// version may look like.
+func ValidVersion(v string) bool {
+	if v == "" || len(v) > maxVersionLen {
+		return false
+	}
+	if v[0] < '0' || v[0] > '9' {
+		return false
+	}
+	// Byte-wise on purpose: any multi-byte rune has bytes >= 0x80 and is
+	// rejected, so no non-ASCII (including bidi/homoglyph) content survives.
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		switch {
+		case c >= '0' && c <= '9',
+			c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c == '.', c == '+', c == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// normalize strips the surrounding whitespace and optional "v" prefix that
+// release tags carry, leaving something semver.NewVersion can accept.
+func normalize(v string) string {
+	v = strings.TrimSpace(v)
+	if len(v) > 0 && (v[0] == 'v' || v[0] == 'V') {
+		v = v[1:]
+	}
+	return v
+}
+
+// looseVersion is the minimal shape needed to order versions the library
+// refuses to parse.
+type looseVersion struct {
+	core [3]uint64
+	pre  string
+}
+
+// parseLoose accepts the same grammar as semver but with every core field
+// optional and no rejection of leading zeros. ok is false when the core is not
+// purely numeric, which is the signal to give up rather than guess.
+func parseLoose(v string) (looseVersion, bool) {
+	var out looseVersion
+
+	v = normalize(v)
+	// Build metadata is explicitly excluded from precedence by semver.
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i]
+	}
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		out.pre = v[i+1:]
+		v = v[:i]
+	}
+	if v == "" {
+		return out, false
+	}
+
+	fields := strings.Split(v, ".")
+	if len(fields) > 3 {
+		return out, false
+	}
+	for i, f := range fields {
+		n, err := strconv.ParseUint(f, 10, 64)
+		if err != nil {
+			return out, false
+		}
+		out.core[i] = n
+	}
+	return out, true
+}
+
+// compareLoose orders versions that Masterminds/semver rejected. Anything it
+// cannot parse either compares equal (0), so an unparsable input is never
+// reported as newer than a real version.
+func compareLoose(a, b string) int {
+	va, okA := parseLoose(a)
+	vb, okB := parseLoose(b)
+	if !okA || !okB {
+		return 0
+	}
+
+	for i := range va.core {
+		if va.core[i] != vb.core[i] {
+			if va.core[i] < vb.core[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return comparePrerelease(va.pre, vb.pre)
+}
+
+// comparePrerelease implements semver's pre-release precedence: a release
+// (empty pre-release) outranks any pre-release of the same core, identifiers
+// are compared dot-wise, numeric identifiers compare numerically and rank
+// below alphanumeric ones, and when all shared identifiers are equal the
+// shorter set ranks lower.
+func comparePrerelease(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return 1
+	}
+	if b == "" {
+		return -1
+	}
+
+	fa := strings.Split(a, ".")
+	fb := strings.Split(b, ".")
+	for i := 0; i < len(fa) && i < len(fb); i++ {
+		if c := compareIdentifier(fa[i], fb[i]); c != 0 {
+			return c
+		}
+	}
+	switch {
+	case len(fa) < len(fb):
+		return -1
+	case len(fa) > len(fb):
+		return 1
+	}
+	return 0
+}
+
+// compareIdentifier orders a single pre-release identifier pair.
+func compareIdentifier(a, b string) int {
+	na, errA := strconv.ParseUint(a, 10, 64)
+	nb, errB := strconv.ParseUint(b, 10, 64)
+
+	switch {
+	case errA == nil && errB == nil:
+		switch {
+		case na < nb:
+			return -1
+		case na > nb:
+			return 1
+		}
+		return 0
+	// Numeric identifiers always have lower precedence than alphanumeric ones.
+	case errA == nil:
+		return -1
+	case errB == nil:
+		return 1
+	}
+	return strings.Compare(a, b)
+}

--- a/internal/update/version_test.go
+++ b/internal/update/version_test.go
@@ -1,0 +1,154 @@
+package update
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{name: "patch ordering", a: "1.0.0", b: "1.0.1", want: -1},
+		{name: "minor ordering", a: "1.1.0", b: "1.0.9", want: 1},
+		{name: "major ordering", a: "2.0.0", b: "10.0.0", want: -1},
+		{name: "equal versions", a: "1.2.3", b: "1.2.3", want: 0},
+
+		// GitHub release tags carry a "v"; ccu's own stamped version does not.
+		{name: "v prefix on one side", a: "v1.2.3", b: "1.2.3", want: 0},
+		{name: "v prefix on both sides", a: "v1.2.4", b: "v1.2.3", want: 1},
+
+		// Missing core fields default to 0.
+		{name: "partial version equals padded", a: "1.2", b: "1.2.0", want: 0},
+		{name: "partial version ordering", a: "1.2", b: "1.2.1", want: -1},
+
+		// Build metadata is excluded from precedence by the semver spec.
+		{name: "build metadata ignored", a: "1.2.3+abc123", b: "1.2.3", want: 0},
+		{name: "build metadata differs only", a: "1.2.3+aaa", b: "1.2.3+zzz", want: 0},
+		{name: "build metadata on prerelease", a: "1.0.0-rc.1+build.7", b: "1.0.0-rc.1", want: 0},
+
+		// A release outranks any prerelease of the same core.
+		{name: "release beats prerelease", a: "1.0.0", b: "1.0.0-rc.1", want: 1},
+		{name: "prerelease loses to release", a: "1.0.0-rc.1", b: "1.0.0", want: -1},
+		{name: "prerelease still loses to lower release core", a: "1.0.0-rc.1", b: "0.9.9", want: 1},
+
+		// The canonical semver precedence chain.
+		{name: "alpha before alpha.1", a: "1.0.0-alpha", b: "1.0.0-alpha.1", want: -1},
+		{name: "alpha.1 before beta", a: "1.0.0-alpha.1", b: "1.0.0-beta", want: -1},
+		{name: "beta before release", a: "1.0.0-beta", b: "1.0.0", want: -1},
+		{name: "numeric identifiers compare numerically", a: "1.0.0-rc.2", b: "1.0.0-rc.10", want: -1},
+		{name: "numeric ranks below alphanumeric", a: "1.0.0-1", b: "1.0.0-alpha", want: -1},
+
+		// Garbage off the network must never sort as newer.
+		{name: "unparsable is not greater", a: "not-a-version", b: "1.0.0", want: 0},
+		{name: "unparsable is not lesser", a: "1.0.0", b: "not-a-version", want: 0},
+		{name: "both unparsable", a: "latest", b: "stable", want: 0},
+		{name: "empty strings", a: "", b: "", want: 0},
+		{name: "escape sequence payload", a: "\x1b[31m1.0.0", b: "1.0.0", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CompareVersions(tt.a, tt.b))
+			// Comparison must be antisymmetric, or ordering would depend on
+			// argument order.
+			assert.Equal(t, -tt.want, CompareVersions(tt.b, tt.a), "reversed")
+		})
+	}
+}
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		name            string
+		latest, current string
+		want            bool
+	}{
+		{name: "newer patch", latest: "1.0.1", current: "1.0.0", want: true},
+		{name: "newer major with v prefix", latest: "v2.0.0", current: "1.9.9", want: true},
+		{name: "same version", latest: "1.0.0", current: "1.0.0", want: false},
+		{name: "same version modulo build metadata", latest: "1.0.0+ci.9", current: "1.0.0", want: false},
+
+		// Strict-newer-only: an older "latest" is a rollback attempt.
+		{name: "downgrade rejected", latest: "0.9.0", current: "1.0.0", want: false},
+		{name: "prerelease of current core rejected", latest: "1.0.0-rc.1", current: "1.0.0", want: false},
+		{name: "prerelease of higher core accepted", latest: "2.0.0-rc.1", current: "1.0.0", want: true},
+
+		// Dev builds are never behind a release.
+		{name: "unstamped current", latest: "9.9.9", current: "", want: false},
+		{name: "dev current", latest: "9.9.9", current: "dev", want: false},
+		{name: "devel current", latest: "9.9.9", current: "(devel)", want: false},
+
+		{name: "malformed latest never triggers update", latest: "latest", current: "1.0.0", want: false},
+		{name: "escape payload never triggers update", latest: "\x1b]0;x\x07", current: "1.0.0", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsNewer(tt.latest, tt.current))
+		})
+	}
+}
+
+func TestIsDevVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		v    string
+		want bool
+	}{
+		{name: "unstamped", v: "", want: true},
+		{name: "dev", v: "dev", want: true},
+		{name: "devel", v: "(devel)", want: true},
+		{name: "surrounding whitespace", v: "  dev  ", want: true},
+		{name: "uppercase", v: "DEV", want: true},
+		{name: "release version", v: "1.0.0", want: false},
+		{name: "prerelease version", v: "1.0.0-dev", want: false},
+		{name: "development spelled out", v: "development", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsDevVersion(tt.v))
+		})
+	}
+}
+
+func TestValidVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		v    string
+		want bool
+	}{
+		{name: "plain semver", v: "1.0.0", want: true},
+		{name: "prerelease", v: "1.0.0-beta.1", want: true},
+		{name: "build metadata", v: "1.0.0+build.7", want: true},
+		{name: "partial version", v: "1.2", want: true},
+		{name: "exactly 64 chars", v: "1" + strings.Repeat("0", 63), want: true},
+
+		{name: "empty", v: "", want: false},
+		{name: "65 chars", v: "1" + strings.Repeat("0", 64), want: false},
+		{name: "leading v", v: "v1.0.0", want: false},
+		{name: "leading letter", v: "latest", want: false},
+		{name: "ansi escape", v: "1.0.0\x1b[31m", want: false},
+		{name: "bare escape byte", v: "1.0.0\x1b", want: false},
+		{name: "forward slash", v: "1.0.0/etc", want: false},
+		{name: "path traversal", v: "1.0.0/../../etc/passwd", want: false},
+		{name: "backslash", v: "1.0.0\\x", want: false},
+		{name: "space", v: "1.0.0 rc1", want: false},
+		{name: "leading space", v: " 1.0.0", want: false},
+		{name: "newline", v: "1.0.0\ninjected", want: false},
+		{name: "carriage return", v: "1.0.0\r", want: false},
+		{name: "nul byte", v: "1.0.0\x00", want: false},
+		{name: "shell metacharacters", v: "1.0.0;rm", want: false},
+		{name: "non-ascii", v: "1.0.0é", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ValidVersion(tt.v))
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,9 +13,15 @@ import (
 	"github.com/padi2312/compose-check-updates/internal/modes"
 	"github.com/padi2312/compose-check-updates/internal/scanner"
 	"github.com/padi2312/compose-check-updates/internal/tui"
+	"github.com/padi2312/compose-check-updates/internal/update"
 )
 
 func main() {
+	// An update renames the running binary aside to "<exe>.old" — on Windows a
+	// running executable cannot be replaced, only moved — so the leftover can
+	// first be deleted by a later process, i.e. this one, before anything else.
+	update.CleanupLeftovers()
+
 	// Set colorized logger
 	logger := slog.New(logger.NewCustomHandler(slog.LevelInfo, os.Stdout))
 	slog.SetDefault(logger)
@@ -23,6 +29,16 @@ func main() {
 	// Version metadata comes from internal/buildinfo, stamped at build time from
 	// the repo-root VERSION file via -ldflags; unstamped dev builds report "dev".
 	ccuFlags := internal.Parse(buildinfo.String())
+
+	// Both are terminal actions in their own right: the user asked about ccu
+	// itself, not about their Compose files, so no scan may start behind them.
+	if ccuFlags.SelfUpdate || ccuFlags.CheckUpdate {
+		if err := update.Run(os.Stdout, buildinfo.Version, ccuFlags.CheckUpdate); err != nil {
+			slog.Error("Error updating ccu", "error", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	opts := scanner.Options{
 		Root:    ccuFlags.Directory,
@@ -58,6 +74,14 @@ func main() {
 		slog.Error("Error checking for updates", "error", err)
 		os.Exit(1)
 	}
+
+	// Only the non-interactive path gets the notice. The TUI swaps out the slog
+	// handler and owns the alt screen, so a stray line written around its
+	// teardown would land on top of the rendered frame; and -self-update /
+	// -check-update returned long before here, where nagging about a version the
+	// user just asked about would be pointless. Stderr rather than stdout, so
+	// piping ccu's report somewhere keeps it machine-readable.
+	update.NotifyIfAvailable(os.Stderr, buildinfo.Version)
 }
 
 // isTerminal reports whether f is attached to a terminal, used to tell a piped


### PR DESCRIPTION
- Implement version comparison and validation logic in version.go
- Create functions to check for newer versions and identify development versions
- Introduce a checksum verification mechanism for binary updates
- Add tests for version comparison, update checks, and checksum validation in version_test.go and update_test.go
- Set up a mock release server for testing update scenarios
- Ensure safe handling of untrusted version inputs to prevent security issues