### PR TITLE
Feat/tui by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,76 @@
 </p>
 
 ```bash
-ccu        # show what's outdated
-ccu -u     # write the new tags
-ccu -i     # pick what to update in a full-screen TUI
+ccu              # open the TUI and pick what to update
+ccu check        # just print what's outdated
+ccu check -u     # print and write the new tags
 ```
 
-## The interactive mode
+Point it at a directory, it scans every Compose file below it, asks each registry
+what's newer, and — if you want — rewrites the tags for you.
 
-`ccu -i` is the nicest way to use this tool.
+---
+
+## Install
+
+Download the binary for your platform from the
+[Releases](https://github.com/p-arndt/compose-check-updates/releases) page.
+
+**Linux / macOS**
+
+```bash
+mv ccu-linux-amd64 ccu && chmod +x ccu
+sudo mv ccu /usr/local/bin/     # optional
+ccu version
+```
+
+**Windows** — rename it to `ccu.exe`, optionally put its directory on your `PATH`,
+then check with `ccu.exe version`.
+
+You can also just run the downloaded file directly (`./ccu-linux-amd64`) without
+installing anything.
+
+Later on, `ccu self-update` replaces the binary in place — see
+[Updating ccu](#updating-ccu).
+
+## Usage
+
+`cd` into the directory holding your stacks and run `ccu`. All subdirectories are
+scanned recursively for Compose files, and the images in their services are
+checked against their registries.
+
+There are two ways to use it:
+
+| | |
+| ---------------- | ---------------------------------------------------------- |
+| **`ccu`**        | The TUI. Browse what's outdated, pick rows, apply. Default. |
+| **`ccu check`**  | One-shot report for scripts, cron and CI. No UI.            |
+
+Nothing is ever written unless you ask for it — `A` in the TUI, `-u` for `check`.
+
+> [!NOTE]
+> Writing creates a backup of every modified Compose file next to it, with a
+> `.ccu` extension.
+
+### The TUI (default)
+
+```bash
+ccu                # scan the current directory
+ccu -d ./stacks    # scan somewhere else
+```
 
 <!-- TODO: drop a screenshot or asciinema gif of the TUI here -->
 
-A full-screen terminal UI: updates grouped per Compose file, colour-coded by level,
-streaming in as the registries answer. Arrow keys to move, `space` to select,
-`A` to apply. Press `?` for everything else.
+A full-screen terminal UI: updates grouped per Compose file, colour-coded by
+level, streaming in as the registries answer. Arrow keys to move, `space` to
+select, `A` to apply. Press `?` for everything else.
 
 Nothing is written until you press `A`, and you decide per row which version gets
-written — so a major bump never sneaks in.
+written — so a major bump never sneaks in. Afterwards `ccu` asks once whether the
+affected Compose files should be restarted with `docker compose up -d`.
 
 <details>
-<summary>All keys and the filter/target model</summary>
+<summary><strong>All keys</strong></summary>
 
 | Key                | Action                                             |
 | ------------------ | -------------------------------------------------- |
@@ -47,85 +97,84 @@ written — so a major bump never sneaks in.
 | `y` / `n`          | Answer the restart prompt                          |
 | `?` / `q`          | Help / quit                                        |
 
-**Filter vs. target** — `show` (`f`) only decides which rows are _visible_;
-`target` (`t`, `T`) decides which version actually gets _written_. The target
-defaults to `major`, so out of the box you are offered the highest available
-version. At target `minor`, an image on `traefik:v2.9.3` that has `3.7.8`
-available re-points to the latest `2.11.x` instead; at `patch`, to `2.9.4`.
+</details>
+
+<details>
+<summary><strong>Filter vs. target</strong> — which version actually gets written</summary>
+
+`show` (`f`) only decides which rows are _visible_; `target` (`t`, `T`) decides
+which version actually gets _written_. The target defaults to `major`, so out of
+the box you are offered the highest available version. At target `minor`, an
+image on `traefik:v2.9.3` that has `3.7.8` available re-points to the latest
+`2.11.x` instead; at `patch`, to `2.9.4`.
+
 `T` only cycles the levels an image actually has — the `(+2)` after a version
 means two other levels exist. A row with nothing at the current target shows as
 `[-] … no patch update` and cannot be applied.
 
-After applying, `ccu` asks once whether the affected Compose files should be
-restarted with `docker compose up -d`.
-
 The TUI always resolves **all** update levels, regardless of `-patch`, `-minor`,
-`-major` or `-f`. Those flags govern the non-interactive mode only. Interactive
-mode needs a real terminal — when stdout is piped, `ccu` exits with a hint to use
-the non-interactive mode.
+`-major` or `-f`. Those flags govern `ccu check` only.
 
 </details>
 
-## Installation
+> [!TIP]
+> The TUI needs a real terminal. When stdout is piped or redirected, `ccu` runs
+> the `check` report instead and says so on stderr — so an old cron entry or CI
+> job keeps working either way.
 
-Download the binary for your platform from the
-[Releases](https://github.com/p-arndt/compose-check-updates/releases) page.
-
-**Windows** — rename it to `ccu.exe`, optionally put its directory on your `PATH`,
-then check with `ccu.exe -v`.
-
-**Linux** — rename it to `ccu`, `chmod +x ccu`, optionally move it to
-`/usr/local/bin`, then check with `ccu -v`.
-
-You can also just run the downloaded file directly (`./ccu-linux-amd64`) without
-installing anything.
-
-## Usage
-
-Run `ccu` in a directory — all subdirectories are scanned recursively for Compose
-files, and the images in their services are checked against their registries.
+### `ccu check` — the non-interactive report
 
 ```bash
-ccu              # report only (patch updates by default)
-ccu -u           # write the new tags
-ccu -u -r        # write, then restart the affected services
-ccu -f           # consider every newer version, not just patches
-ccu -d ./stacks  # scan a different directory
+ccu check              # report only (patch updates by default)
+ccu check -u           # write the new tags
+ccu check -u -r        # write, then restart the affected services
+ccu check -f           # consider every newer version, not just patches
+ccu check -d ./stacks  # scan a different directory
 ```
 
+Every flag below applies to `ccu check`; only `-d` and `-exclude` also apply to
+the TUI, which picks levels in the UI instead.
+
+| Flag       | Description                                              | Default |
+| ---------- | -------------------------------------------------------- | ------- |
+| `-d`       | Directory to scan                                        | `.`     |
+| `-exclude` | Directories to exclude, comma-separated                  | none    |
+| `-u`       | Update the Compose files with the new image tags         | `false` |
+| `-r`       | Restart the services after updating                      | `false` |
+| `-f`       | Full mode — consider every newer version, not just patches | `false` |
+| `-major`   | Only suggest major version updates                       | `false` |
+| `-minor`   | Only suggest minor version updates                       | `false` |
+| `-patch`   | Only suggest patch version updates                       | `true`  |
+
+### All commands
+
+```bash
+ccu                # the TUI
+ccu check          # the non-interactive report
+ccu self-update    # download, verify and replace the running binary
+ccu check-update   # only report whether a newer ccu exists
+ccu help           # show the help message
+ccu version        # show version information
+```
+
+The last four act on `ccu` itself and ignore the flags above.
+
 > [!NOTE]
-> `-u` creates a backup of every modified Compose file with a `.ccu` extension.
+> **Coming from v0.6.x?** The report used to be the default and `-i` opened the
+> TUI. That is now the other way round. Both old spellings still work: `-i` is
+> accepted as a no-op, and a report-only flag without `check` (`ccu -u`) still
+> runs the report, printing a one-line hint about the new spelling.
 
-### Flags
-
-> [!IMPORTANT]
-> With `-i`, all flags except `-d` and `-exclude` are ignored.
-
-| Flag       | Description                                                    | Default   |
-| ---------- | -------------------------------------------------------------- | --------- |
-| `-h`       | Show help message                                              | `false`   |
-| `-u`       | Update the Compose files with the new image tags               | `false`   |
-| `-r`       | Restart the services after updating                            | `false`   |
-| `-i`       | Launch the full-screen TUI                                     | `false`   |
-| `-d`       | Directory to scan                                              | `.`       |
-| `-f`       | Full update mode — check up to the latest semver version       | `false`   |
-| `-major`   | Only suggest major version updates                             | `false`   |
-| `-minor`   | Only suggest minor version updates                             | `false`   |
-| `-patch`   | Only suggest patch version updates                             | `true`    |
-| `-exclude` | Exclude services from being updated (comma-separated)          | `none`    |
-
-### Commands
-
-These act on `ccu` itself and ignore the flags above.
+## Updating ccu
 
 ```bash
 ccu self-update    # download, verify and replace the running binary
 ccu check-update   # only report whether something newer exists
 ```
 
-A normal (non-interactive) run also checks **at most once every 24 hours** whether
-a newer release exists and prints one line to stderr if so — stdout stays clean.
-It never installs anything by itself.
+A `ccu check` run also checks **at most once every 24 hours** whether a newer
+release exists and prints one line to stderr if so — stdout stays clean. It never
+installs anything by itself.
 
 <details>
 <summary>Update-check details</summary>
@@ -166,9 +215,10 @@ major/minor/patch level, so it is always reported and is unaffected by `-major`,
 <details>
 <summary>No new versions found, but newer versions exist</summary>
 
-By default `ccu` only checks for **patch** versions. With a current tag of `1.0.0`
-and a latest tag of `1.1.0`, there is no newer patch version, so nothing is
-suggested. Use `ccu -f` to consider every newer version.
+By default `ccu check` only checks for **patch** versions. With a current tag of
+`1.0.0` and a latest tag of `1.1.0`, there is no newer patch version, so nothing
+is suggested. Use `ccu check -f` to consider every newer version — or just use the
+TUI, which always resolves every level.
 
 </details>
 
@@ -181,5 +231,15 @@ if you use `13.2`, `ccu` will not suggest `13.4`, because `13` is not a valid
 semver version.
 
 _(This might change in the future behind an additional flag.)_
+
+</details>
+
+<details>
+<summary>The TUI does not open</summary>
+
+`ccu` falls back to the `check` report when stdout is not a terminal — inside a
+pipe (`ccu | less`), a redirect (`ccu > out.txt`), or a CI job. The stderr line
+tells you when that happened. Run `ccu` with its output attached to the terminal
+to get the UI.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ what's newer, and — if you want — rewrites the tags for you.
 
 ---
 
-## Install
+# Install
 
 Download the binary for your platform from the
 [Releases](https://github.com/p-arndt/compose-check-updates/releases) page.
@@ -41,7 +41,7 @@ installing anything.
 Later on, `ccu self-update` replaces the binary in place — see
 [Updating ccu](#updating-ccu).
 
-## Usage
+# Usage
 
 `cd` into the directory holding your stacks and run `ccu`. All subdirectories are
 scanned recursively for Compose files, and the images in their services are
@@ -60,7 +60,7 @@ Nothing is ever written unless you ask for it — `A` in the TUI, `-u` for `chec
 > Writing creates a backup of every modified Compose file next to it, with a
 > `.ccu` extension.
 
-### The TUI (default)
+## The TUI (default)
 
 ```bash
 ccu                # scan the current directory
@@ -122,7 +122,7 @@ The TUI always resolves **all** update levels, regardless of `-patch`, `-minor`,
 > the `check` report instead and says so on stderr — so an old cron entry or CI
 > job keeps working either way.
 
-### `ccu check` — the non-interactive report
+## `ccu check` — the non-interactive report
 
 ```bash
 ccu check              # report only (patch updates by default)
@@ -146,7 +146,7 @@ the TUI, which picks levels in the UI instead.
 | `-minor`   | Only suggest minor version updates                       | `false` |
 | `-patch`   | Only suggest patch version updates                       | `true`  |
 
-### All commands
+## All commands
 
 ```bash
 ccu                # the TUI
@@ -165,7 +165,7 @@ The last four act on `ccu` itself and ignore the flags above.
 > accepted as a no-op, and a report-only flag without `check` (`ccu -u`) still
 > runs the report, printing a one-line hint about the new spelling.
 
-## Updating ccu
+# Updating ccu
 
 ```bash
 ccu self-update    # download, verify and replace the running binary
@@ -188,7 +188,7 @@ scripts keep running, but the subcommands above are the supported form.
 
 </details>
 
-## Images without semver tags
+# Images without semver tags
 
 Not every image publishes semantic versions. Some are pinned by digest, others tag
 every build with its commit (e.g. `ghcr.io/vert-sh/vert` with `sha-e1c83ba` tags).

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
+	"text/tabwriter"
 )
 
 type CCUFlags struct {
@@ -13,6 +15,8 @@ type CCUFlags struct {
 	Update      bool     // Update the Docker Compose files with the new image tags
 	Restart     bool     // Restart the services after updating the Docker Compose files
 	Interactive bool     // Interactively choose which docker images to update
+	Check       bool     // Run the non-interactive report instead of the TUI
+	LegacyPlain bool     // Check was inferred from a report-only flag rather than the `check` subcommand
 	Directory   string   // Root directory to search for Docker Compose files
 	Full        bool     // Update to the latest semver version
 	Major       bool     // Update to the latest major version
@@ -25,11 +29,19 @@ type CCUFlags struct {
 	ExcludeStr  string   // Comma-separated list of directories to exclude from search (flag only)
 }
 
-// splitSubcommand pulls a leading subcommand off the argument list. These two
-// actions operate on ccu itself rather than on the user's compose files, and
-// they ignore every scan option — `ccu self-update -d /srv` never had a
-// meaning — so a subcommand states the shape of the invocation better than a
-// flag that silently coexists with flags it will not read.
+// plainOnlyFlags are the flags that only the non-interactive report reads: the
+// TUI resolves every level itself and applies on a keypress. Naming one of them
+// therefore states which mode was meant, even when `check` was left out.
+var plainOnlyFlags = map[string]bool{
+	"u": true, "r": true, "f": true, "major": true, "minor": true, "patch": true,
+}
+
+// splitSubcommand pulls a leading subcommand off the argument list. These
+// actions each pick a mode of their own — `check` the non-interactive report,
+// the rest something about ccu itself rather than about the user's compose
+// files — and they ignore the options the other modes read, so a subcommand
+// states the shape of the invocation better than a flag that silently coexists
+// with flags it will not read.
 //
 // Anything else is handed back untouched, which keeps an unrecognised bare
 // argument doing exactly what it did before: nothing.
@@ -38,7 +50,7 @@ func splitSubcommand(argv []string) (sub string, rest []string) {
 		return "", argv
 	}
 	switch argv[0] {
-	case "self-update", "check-update":
+	case "check", "self-update", "check-update", "help", "version":
 		return argv[0], argv[1:]
 	}
 	return "", argv
@@ -52,10 +64,13 @@ func Parse(version string) CCUFlags {
 	flag.BoolVar(&args.Help, "h", false, "Show help message")
 	flag.BoolVar(&args.Update, "u", false, "Update the Docker Compose files with the new image tags")
 	flag.BoolVar(&args.Restart, "r", false, "Restart the services after updating the Docker Compose files")
-	flag.BoolVar(&args.Interactive, "i", false, "Interactively choose which docker images to update")
+	// The TUI is what a bare `ccu` runs now, so -i no longer selects anything;
+	// it stays registered, and hidden from the usage text, so the invocation it
+	// used to name keeps working.
+	flag.BoolVar(&args.Interactive, "i", false, "")
 	flag.StringVar(&args.Directory, "d", ".", "Root directory to search for Docker Compose files")
-	flag.BoolVar(&args.Full, "f", false, "Update to the latest major version")
-	flag.BoolVar(&args.Major, "major", false, "Update to the latest semver version")
+	flag.BoolVar(&args.Full, "f", false, "Consider every newer version, not just patches")
+	flag.BoolVar(&args.Major, "major", false, "Update to the latest major version")
 	flag.BoolVar(&args.Minor, "minor", false, "Update to the latest minor version")
 	flag.BoolVar(&args.Patch, "patch", true, "Update to the latest patch version")
 	flag.BoolVar(&args.Version, "v", false, "Show version information")
@@ -71,11 +86,40 @@ func Parse(version string) CCUFlags {
 	flag.Usage = func() { usage(flag.CommandLine.Output()) }
 	flag.CommandLine.Parse(rest)
 
+	// A word that reached here is not one of the subcommands above, and flag
+	// parsing stopped at it — so `ccu nonsense -d /srv` would silently have
+	// ignored the -d as well. Now that there is a command surface to mistype,
+	// say so instead of scanning the wrong directory.
+	if flag.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", flag.Arg(0))
+		usage(os.Stderr)
+		os.Exit(2)
+	}
+
 	switch sub {
+	case "check":
+		args.Check = true
 	case "self-update":
 		args.SelfUpdate = true
 	case "check-update":
 		args.CheckUpdate = true
+	case "help":
+		args.Help = true
+	case "version":
+		args.Version = true
+	}
+
+	// A report-only flag without `check` is what every pre-TUI-default script
+	// looks like. Launching the TUI at it would be worse than useless — `ccu -u`
+	// in a cron entry would hang on a terminal that is not there — so the mode
+	// those flags imply is honoured, and main says once which spelling replaced
+	// it. Not for -i: that one means the TUI, which is now the default anyway.
+	if !args.Check {
+		flag.Visit(func(f *flag.Flag) {
+			if plainOnlyFlags[f.Name] {
+				args.Check, args.LegacyPlain = true, true
+			}
+		})
 	}
 
 	if args.Version {
@@ -111,20 +155,32 @@ func Parse(version string) CCUFlags {
 // left out: they still work, but a help text listing both forms would suggest
 // there is a difference between them.
 func usage(w io.Writer) {
-	fmt.Fprintf(w, "Usage:\n  %s [flags]\n  %s <command>\n\nCommands:\n", os.Args[0], os.Args[0])
-	fmt.Fprintln(w, "  self-update\tDownload and install the latest version of ccu")
-	fmt.Fprintln(w, "  check-update\tCheck whether a newer version of ccu is available, without installing it")
-	fmt.Fprintln(w, "\nFlags:")
+	// The invocation name only, not the path it happened to be started from:
+	// help text that reads `/tmp/build/ccu check` teaches the wrong command.
+	name := filepath.Base(os.Args[0])
+
+	// A tabwriter rather than plain tabs, so the descriptions line up whatever
+	// the longest command or flag name turns out to be.
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "Usage:\n  %s\tPick what to update in the full-screen TUI\n", name)
+	fmt.Fprintf(tw, "  %s <command>\tRun one of the commands below\n\nCommands:\n", name)
+	fmt.Fprintln(tw, "  check\tReport the available updates without the TUI, and optionally apply them")
+	fmt.Fprintln(tw, "  self-update\tDownload and install the latest version of ccu")
+	fmt.Fprintln(tw, "  check-update\tCheck whether a newer version of ccu is available, without installing it")
+	fmt.Fprintln(tw, "  help\tShow this help message")
+	fmt.Fprintln(tw, "  version\tShow version information")
+	fmt.Fprintf(tw, "\nFlags (-d and -exclude apply to both modes, the rest only to `%s check`):\n", name)
 	flag.VisitAll(func(f *flag.Flag) {
 		// An empty usage string marks a flag kept only for backwards
 		// compatibility; see the registrations in Parse.
 		if f.Usage == "" {
 			return
 		}
-		fmt.Fprintf(w, "  -%s\t%s", f.Name, f.Usage)
+		fmt.Fprintf(tw, "  -%s\t%s", f.Name, f.Usage)
 		if f.DefValue != "" && f.DefValue != "false" {
-			fmt.Fprintf(w, " (default %s)", f.DefValue)
+			fmt.Fprintf(tw, " (default %s)", f.DefValue)
 		}
-		fmt.Fprintln(w)
+		fmt.Fprintln(tw)
 	})
+	tw.Flush()
 }

--- a/internal/flags_test.go
+++ b/internal/flags_test.go
@@ -6,6 +6,82 @@ import (
 	"testing"
 )
 
+func TestSplitSubcommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		argv     []string
+		wantSub  string
+		wantRest []string
+	}{
+		{name: "no arguments", argv: nil, wantSub: "", wantRest: nil},
+		{name: "check", argv: []string{"check", "-u"}, wantSub: "check", wantRest: []string{"-u"}},
+		{name: "help", argv: []string{"help"}, wantSub: "help", wantRest: []string{}},
+		{name: "version", argv: []string{"version"}, wantSub: "version", wantRest: []string{}},
+		{name: "self-update", argv: []string{"self-update"}, wantSub: "self-update", wantRest: []string{}},
+		{name: "check-update", argv: []string{"check-update"}, wantSub: "check-update", wantRest: []string{}},
+		// A leading flag is never a subcommand, and an unknown word is handed
+		// back so it keeps being ignored rather than changing the mode.
+		{name: "leading flag", argv: []string{"-d", "check"}, wantSub: "", wantRest: []string{"-d", "check"}},
+		{name: "unknown word", argv: []string{"nonsense"}, wantSub: "", wantRest: []string{"nonsense"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub, rest := splitSubcommand(tt.argv)
+			if sub != tt.wantSub {
+				t.Errorf("splitSubcommand(%q) sub = %q, expected %q", tt.argv, sub, tt.wantSub)
+			}
+			if len(rest) != len(tt.wantRest) {
+				t.Fatalf("splitSubcommand(%q) rest = %q, expected %q", tt.argv, rest, tt.wantRest)
+			}
+			for i := range rest {
+				if rest[i] != tt.wantRest[i] {
+					t.Errorf("splitSubcommand(%q) rest[%d] = %q, expected %q", tt.argv, i, rest[i], tt.wantRest[i])
+				}
+			}
+		})
+	}
+}
+
+// TestParseMode covers which mode an invocation selects: the TUI (Check false)
+// is what a bare run means now, and everything that only the report reads has
+// to end up in the report either way.
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		wantCheck       bool
+		wantLegacyPlain bool
+	}{
+		{name: "bare run means the TUI", args: []string{}},
+		{name: "-i still means the TUI", args: []string{"-i"}},
+		{name: "-d alone stays interactive", args: []string{"-d", "/srv"}},
+		{name: "check subcommand", args: []string{"check"}, wantCheck: true},
+		{name: "check with flags", args: []string{"check", "-u", "-r"}, wantCheck: true},
+		{name: "bare -u infers the report", args: []string{"-u"}, wantCheck: true, wantLegacyPlain: true},
+		{name: "bare -f infers the report", args: []string{"-f"}, wantCheck: true, wantLegacyPlain: true},
+		{name: "bare -patch infers the report", args: []string{"-patch"}, wantCheck: true, wantLegacyPlain: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origArgs := os.Args
+			defer func() { os.Args = origArgs }()
+			os.Args = append([]string{"ccu"}, tt.args...)
+
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+
+			result := Parse("test")
+			if result.Check != tt.wantCheck {
+				t.Errorf("Parse(%q).Check = %v, expected %v", tt.args, result.Check, tt.wantCheck)
+			}
+			if result.LegacyPlain != tt.wantLegacyPlain {
+				t.Errorf("Parse(%q).LegacyPlain = %v, expected %v", tt.args, result.LegacyPlain, tt.wantLegacyPlain)
+			}
+		})
+	}
+}
+
 func TestParse(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ default:
 # Dev
 # ---------------------------------------------------------------------------
 
-# Run the CLI from source, passing through any args:  just run -d . -i
+# Run the CLI from source, passing through any args:  just run check -d .
 run *ARGS:
     go run . {{ARGS}}
 

--- a/main.go
+++ b/main.go
@@ -48,21 +48,33 @@ func main() {
 		Patch:   ccuFlags.Patch,
 	}
 
-	if ccuFlags.Interactive {
+	// The TUI is what a bare `ccu` means; `ccu check` is the way to ask for the
+	// report instead. A piped or redirected stdout has no frame to draw on, so
+	// rather than fail at something the user never spelled out, the run falls
+	// back to the report — that is what `ccu | tee`, a CI job or a cron entry
+	// wants anyway.
+	if !ccuFlags.Check && !isTerminal(os.Stdout) {
+		slog.Warn("No terminal on stdout, running the non-interactive report instead of the TUI; use `ccu check` to select it explicitly")
+		ccuFlags.Check = true
+	}
+
+	if !ccuFlags.Check {
 		// The TUI narrows the list with its own in-UI level filter, so it needs every
 		// level resolved up front — re-scanning whenever the filter changes would mean
 		// hitting the registries again for versions we already looked up.
 		opts.Major, opts.Minor, opts.Patch = true, true, true
 
 		if err := tui.Run(opts); err != nil {
-			if !isTerminal(os.Stdout) {
-				slog.Error("Interactive mode needs a terminal; run without -i to check for updates non-interactively", "error", err)
-			} else {
-				slog.Error("Error running interactive mode", "error", err)
-			}
+			slog.Error("Error running interactive mode", "error", err)
 			os.Exit(1)
 		}
 		return
+	}
+
+	// Said once, before the report itself, so an existing script keeps working
+	// and still gets told which spelling replaced it.
+	if ccuFlags.LegacyPlain {
+		slog.Warn("Report-only flags now belong to the `check` subcommand; use `ccu check ...` — the bare form still works for this release")
 	}
 
 	// The TUI installs its own quit handling, so only the non-interactive path


### PR DESCRIPTION
This pull request significantly refactors the CLI interface and documentation for `ccu`, making the TUI (interactive mode) the default, introducing explicit subcommands, and improving usability and help text. It also updates the test suite to cover the new invocation patterns.

**Command-line interface overhaul and improved user experience:**

* The TUI is now the default mode (`ccu`), and the non-interactive report is explicitly invoked with `ccu check`. Old invocations like `ccu -u` are still supported but print a hint about the new syntax. The `-i` flag is now a no-op for backward compatibility. [[1]](diffhunk://#diff-110ee5dc6aa938a807b5b5e5a4c1a2916f508e0b38b5a788c37de4def678db72L55-R73) [[2]](diffhunk://#diff-110ee5dc6aa938a807b5b5e5a4c1a2916f508e0b38b5a788c37de4def678db72R89-R122) [[3]](diffhunk://#diff-110ee5dc6aa938a807b5b5e5a4c1a2916f508e0b38b5a788c37de4def678db72L28-R44) [[4]](diffhunk://#diff-110ee5dc6aa938a807b5b5e5a4c1a2916f508e0b38b5a788c37de4def678db72L114-R185)
* Added new subcommands: `check`, `self-update`, `check-update`, `help`, and `version`. Unknown commands now print an error and usage. [[1]](diffhunk://#diff-110ee5dc6aa938a807b5b5e5a4c1a2916f508e0b38b5a788c37de4def678db72L41-R53) [[2]](diffhunk://#diff-110ee5dc6aa938a807b5b5e5a4c1a2916f508e0b38b5a788c37de4def678db72R89-R122)
* The help output is now clearer, using a tabwriter for alignment, and only lists relevant flags for each mode.
* The CLI now detects when it's not running in a terminal and automatically falls back to the non-interactive report, printing a message to stderr. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R177) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R245)

**Documentation and usage improvements:**

* The `README.md` is extensively rewritten to explain the new command structure, default behaviors, and migration notes for users of previous versions. Examples and detailed descriptions are provided for both the TUI and `check` report modes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L12-R81) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R177) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R191) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L169-R221) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R245)
* Installation and update instructions are clarified and separated by platform.

**Testing and developer workflow:**

* Added comprehensive tests for subcommand parsing and mode selection, ensuring legacy and new invocations behave as intended.
* Updated the development `justfile` to match the new CLI usage patterns.

These changes modernize the CLI, improve discoverability for new users, and ensure backward compatibility for existing scripts and workflows.